### PR TITLE
Skycube Buffer

### DIFF
--- a/Sources/VimKit/Renderer/VimRenderer+Skycube.swift
+++ b/Sources/VimKit/Renderer/VimRenderer+Skycube.swift
@@ -78,14 +78,11 @@ extension VimRenderer {
             depthStencilDescriptor.depthCompareFunction = .lessEqual
             depthStencilDescriptor.isDepthWriteEnabled = true
 
-            guard let depthStencilState = device.makeDepthStencilState(descriptor: depthStencilDescriptor) else {
+            guard let depthStencilState = device.makeDepthStencilState(descriptor: depthStencilDescriptor),
+                  let pipelineState = try? device.makeRenderPipelineState(descriptor: pipelineDescriptor) else {
                 return nil
             }
             self.depthStencilState = depthStencilState
-
-            guard let pipelineState = try? device.makeRenderPipelineState(descriptor: pipelineDescriptor) else {
-                return nil
-            }
             self.pipelineState = pipelineState
         }
 

--- a/Sources/VimKit/Renderer/VimRenderer+Skycube.swift
+++ b/Sources/VimKit/Renderer/VimRenderer+Skycube.swift
@@ -30,14 +30,19 @@ extension VimRenderer {
             }
 
             let allocator = MTKMeshBufferAllocator(device: device)
-            let cube = MDLMesh(boxWithExtent: .one, segments: .one, inwardNormals: true, geometryType: .triangles, allocator: allocator)
+            let cube = MDLMesh(boxWithExtent: .one,
+                               segments: .one,
+                               inwardNormals: true,
+                               geometryType: .triangles,
+                               allocator: allocator)
             guard let cubeMesh = try? MTKMesh(mesh: cube, device: device) else { return nil }
             mesh = cubeMesh
 
+            let textureDimensions: SIMD2<Int32> = [160, 160]
             let textureLoader = MTKTextureLoader(device: device)
             let mdkSkycubeTexture = MDLSkyCubeTexture(name: nil,
                                         channelEncoding: .uInt8,
-                                        textureDimensions: [Int32(160), Int32(160)],
+                                        textureDimensions: textureDimensions,
                                         turbidity: 0,
                                         sunElevation: 0,
                                         upperAtmosphereScattering: 0,

--- a/Sources/VimKit/Renderer/VimRenderer+Skycube.swift
+++ b/Sources/VimKit/Renderer/VimRenderer+Skycube.swift
@@ -92,8 +92,6 @@ extension VimRenderer {
             renderEncoder.setDepthStencilState(depthStencilState)
 
             // Set the buffers to pass to the GPU
-            var instanceUniforms = InstanceUniforms(identifier: .empty, matrix: .identity, color: .zero, glossiness: .zero, smoothness: .zero, xRay: false)
-            renderEncoder.setVertexBytes(&instanceUniforms, length: MemoryLayout<InstanceUniforms>.size, index: .instanceUniforms)
             renderEncoder.setVertexBuffer(mesh.vertexBuffers[0].buffer, offset: 0, index: .positions)
             renderEncoder.setFragmentTexture(texture, index: 0)
 

--- a/Sources/VimKitShaders/Resources/Skycube.metal
+++ b/Sources/VimKitShaders/Resources/Skycube.metal
@@ -38,7 +38,6 @@ typedef struct {
 
 vertex VertexOut vertexSkycube(VertexIn in [[stage_in]],
                               constant UniformsArray &uniformsArray [[ buffer(BufferIndexUniforms) ]],
-                              constant InstanceUniforms &instanceUniforms [[ buffer(BufferIndexInstanceUniforms) ]],
                               uint vertex_id [[vertex_id]],
                               ushort amp_id [[amplification_id]]) {
     
@@ -52,16 +51,14 @@ vertex VertexOut vertexSkycube(VertexIn in [[stage_in]],
     
     VertexOut out;
     out.position = (viewProjectionMatrix * in.position).xyww;
-    out.color = instanceUniforms.color;
+    out.color = float4(0, 0, 0, 0);
     out.textureCoordinates = in.position.xyz;
-    out.identifier = instanceUniforms.identifier;
+    out.identifier = -1; // Denotes an invalid selection
     return out;
 }
 
 fragment ColorOut fragmentSkycube(VertexOut in [[stage_in]],
                                   texturecube<float> cubeTexture [[texture(0)]]) {
-//    constexpr sampler default_sampler(filter::linear);
-//    float4 color = cubeTexture.sample(default_sampler, in.textureCoordinates);
     ColorOut out;
     out.color = in.color;
     out.identifier = in.identifier;


### PR DESCRIPTION
# Description

Removed the unnecessary vertex buffer argument passing `InstanceUniforms` to the Skycube vertex function.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
