### PR TITLE
MTLBuffer Extension Improvements

### DIFF
--- a/Sources/VimKit/Extensions/MTLBuffer+Extensions.swift
+++ b/Sources/VimKit/Extensions/MTLBuffer+Extensions.swift
@@ -19,9 +19,9 @@ public extension MTLBuffer {
     }
 
     /// Builds an UnsafeMutableBufferPointer from the buffer contents.
-    /// - Parameter count: the count of elements inside the buffer
     /// - Returns: a mutable buffer pointer of the specified type and
-    func toUnsafeMutableBufferPointer<T>(_ count: Int) -> UnsafeMutableBufferPointer<T> {
+    func toUnsafeMutableBufferPointer<T>() -> UnsafeMutableBufferPointer<T> {
+        let count = length/MemoryLayout<T>.stride
         let pointer: UnsafeMutablePointer<T> = contents().assumingMemoryBound(to: T.self)
         let bufferPointer = UnsafeMutableBufferPointer(start: pointer, count: count)
         return bufferPointer

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -77,8 +77,6 @@ public class Geometry: ObservableObject {
 
         // 1) Build the positions (vertex) buffer
         let positions = attributes(association: .vertex, semantic: .position)
-        self.positionsCount = positions.reduce(0) { $0 + $1.buffer.data.count(of: Float.self) }
-
         guard let positionsBuffer = positions.makeBufferNoCopy(device: device, type: Float.self) else {
             fatalError("💀 Unable to create positions buffer")
         }
@@ -87,7 +85,6 @@ public class Geometry: ObservableObject {
 
         // 2) Build the index buffer
         let indices = attributes(association: .corner, semantic: .index)
-        self.indicesCount = indices.reduce(0) { $0 + $1.buffer.data.count(of: UInt32.self) }
         guard let indexBuffer = indices.makeBufferNoCopy(device: device, type: UInt32.self) else {
             fatalError("💀 Unable to create index buffer")
         }
@@ -134,23 +131,19 @@ public class Geometry: ObservableObject {
 
     // MARK: Postions (Vertex Buffer Raw Data)
 
-    private var positionsCount: Int = 0
-
     /// Returns the combinded vertex buffer of all of the vertices for all the meshes layed out in slices of [x,y,z].
     public lazy var positions: UnsafeMutableBufferPointer<Float> = {
         assert(positionsBuffer != nil, "💩 Misuse [positions]")
-        return positionsBuffer!.toUnsafeMutableBufferPointer(positionsCount)
+        return positionsBuffer!.toUnsafeMutableBufferPointer()
     }()
 
     // MARK: Index Buffer
-
-    private var indicesCount: Int = 0
 
     /// Returns the combined index buffer of all the meshes (one index per corner, and per half-edge).
     /// The values in this index buffer are relative to the beginning of the vertex buffer.
     public lazy var indices: UnsafeMutableBufferPointer<UInt32> = {
         assert(indexBuffer != nil, "💩 Misuse [indices]")
-        return indexBuffer!.toUnsafeMutableBufferPointer(indicesCount)
+        return indexBuffer!.toUnsafeMutableBufferPointer()
     }()
 
     // MARK: Vertices


### PR DESCRIPTION
# Description

Removing the need to hold the count of the elements inside the `MTLBuffer` and simply calculating the count based on the 
`MTLBuffer` length divided by the type's `MemoryLayout` stride.

```let count = length/MemoryLayout<T>.stride```

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
