### PR TITLE
Instancing

### DIFF
--- a/Sources/VimKit/Geometry+Mesh.swift
+++ b/Sources/VimKit/Geometry+Mesh.swift
@@ -11,16 +11,17 @@ extension Geometry {
 
     public class Instance {
 
-        /// The identifier of the instance
-        public let idenitifer: Int
-        /// 4x4 row-major matrix representing the node's world-space transform
-        public let matrix: float4x4
-        /// The first bit of each flag designates whether the instance should be initially hidden (1) or not (0) when rendered.
-        public let flags: Int16
+        /// Represents the state of the instance.
+        public enum State: Int {
+            case `default`
+            case hidden
+            case selected
+        }
+
+        /// The index of the instance
+        public let index: Int
         /// Marks the instance as hidden
-        public var hidden: Bool = false
-        /// Marks the instance as selected
-        public var selected: Bool = false
+        public var state: State = .default
         /// Flag indicating if the instance is transparent or not.
         public var transparent: Bool = false
         /// A reference to the parent instance
@@ -39,16 +40,13 @@ extension Geometry {
         /// Initializes the instance.
         /// 
         /// - Parameters:
-        ///   - identifier: the instance unique identifier. Use this to find instances
+        ///   - index: The instance index. Use this to find instances
         ///     within the geometry rather than the subscript as
         ///     the array of instances will most likely be sorted differently.
-        ///   - matrix: The 4x4 row-major matrix representing the node's world-space transform
         ///   - flags: Holds the flags for the given instance.
-        init(identifier: Int, matrix: float4x4 = .identity, flags: Int16) {
-            self.idenitifer = identifier
-            self.matrix = matrix
-            self.flags = flags
-            self.hidden = flags != .zero
+        init(index: Int, flags: Int16) {
+            self.index = index
+            self.state = flags != .zero ? .hidden : .default
         }
     }
 
@@ -67,6 +65,32 @@ extension Geometry {
         ///   - submeshes: The range of submeshes contained inside this mesh
         init(submeshes: Range<Int>? = nil) {
             self.submeshes = submeshes
+        }
+    }
+
+    /// Inverts the relationship between an Instance and a Mesh that allows us to draw using instancing.
+    class Instanced {
+
+        /// The mesh that is shared across the instances.
+        let mesh: Mesh
+        /// Flag indicating if the mesh is transparent or not
+        let transparent: Bool
+        /// The instance indexes.
+        let instances: [UInt32]
+        /// Provides an offset into the transforms buffer.
+        var baseInstance: Int
+
+        /// Initalizes the instanced mesh.
+        /// - Parameters:
+        ///   - mesh: the mesh that should be instanced
+        ///   - transparent: a flag indicating if the instance is transparent or not (used primarily for sorting).
+        ///   - instances: the instance indexes
+        ///   - baseInstance: the offset used by the GPU used to lookup the starting index into the transforms buffer.
+        init(mesh: Mesh, transparent: Bool, instances: [UInt32], _ baseInstance: Int = 0) {
+            self.mesh = mesh
+            self.transparent = transparent
+            self.instances = instances
+            self.baseInstance = baseInstance
         }
     }
 

--- a/Sources/VimKit/Geometry+Mesh.swift
+++ b/Sources/VimKit/Geometry+Mesh.swift
@@ -53,7 +53,7 @@ extension Geometry {
     }
 
     /// A mesh is composed of 0 or more submeshes.
-    public struct Mesh {
+    public struct Mesh: Equatable, Hashable {
 
         /// The range of submeshes contained inside this mesh.
         ///

--- a/Sources/VimKit/Vim.swift
+++ b/Sources/VimKit/Vim.swift
@@ -214,9 +214,7 @@ public class Vim: NSObject, ObservableObject {
             assert(false, "The geometry block is absent")
             return
         }
-        assert(geometry.instanceTransforms.count == count, "The number of transforms doesn't match the instance count.")
-        assert(geometry.instanceParents.count == count, "The number of instance parents doesn't match the instance count.")
-        assert(geometry.instanceMeshes.count == count, "The number of instance meshes doesn't match the instance count.")
+        assert(geometry.transforms.count == count, "The number of transforms doesn't match the instance count.")
 
         guard let materialsTable = db?.Material else {
             assert(false, "The materials table doesn't exist in the database")

--- a/Sources/VimKitShaders/Resources/Shaders.metal
+++ b/Sources/VimKitShaders/Resources/Shaders.metal
@@ -55,7 +55,16 @@ typedef struct {
     int32_t index [[color(1)]];
 } ColorOut;
 
-// The main vertex shader function
+// The main vertex shader function.
+// - Parameters:
+//   - in: The vertex position + normal data.
+//   - amp_id: The index into the uniforms array used for stereoscopic views in visionOS.
+//   - instance_id: The baseInstance parameter passed to the draw call used to map this instance to it's transform data.
+//   - uniformsArray: The per frame uniforms.
+//   - meshUniforms: The per mesh uniforms.
+//   - transforms: The instance transform matrices.
+//   - instanceOffsets: The current instance index into the transforms pointer.
+//   - xRay: Flag indicating if this frame is being rendered in xray mode.
 vertex VertexOut vertexMain(Vertex in [[stage_in]],
                             ushort amp_id [[amplification_id]],
                             uint vertex_id [[vertex_id]],
@@ -106,7 +115,11 @@ vertex VertexOut vertexMain(Vertex in [[stage_in]],
     return out;
 }
 
-// The primary fragment shader function that includes the texture
+// The main fragment shader function.
+// - Parameters:
+//   - in: the data passed from the vertex function.
+//   - texture: the texture.
+//   - colorSampler: The color sampler.
 fragment ColorOut fragmentMain(VertexOut in [[stage_in]],
                               texture2d<float, access::sample> texture [[texture(0)]],
                               sampler colorSampler [[sampler(0)]]) {

--- a/Sources/VimKitShaders/Resources/Shaders.metal
+++ b/Sources/VimKitShaders/Resources/Shaders.metal
@@ -69,11 +69,11 @@ vertex VertexOut vertexMain(Vertex in [[stage_in]],
                             ushort amp_id [[amplification_id]],
                             uint vertex_id [[vertex_id]],
                             uint instance_id [[instance_id]],
-                            constant UniformsArray &uniformsArray [[ buffer(BufferIndexUniforms) ]],
-                            constant MeshUniforms &meshUniforms [[ buffer(BufferIndexMeshUniforms) ]],
-                            constant float4x4 *transforms [[ buffer(BufferIndexTransforms) ]],
-                            constant uint32_t *instanceOffsets [[ buffer(BufferIndexInstanceOffsets) ]],
-                            constant bool &xRay [[ buffer(BufferIndexXRay) ]]) {
+                            constant UniformsArray &uniformsArray [[buffer(BufferIndexUniforms)]],
+                            constant MeshUniforms &meshUniforms [[buffer(BufferIndexMeshUniforms)]],
+                            constant float4x4 *transforms [[buffer(BufferIndexTransforms)]],
+                            constant uint32_t *instanceOffsets [[buffer(BufferIndexInstanceOffsets)]],
+                            constant bool &xRay [[buffer(BufferIndexXRay)]]) {
 
     uint32_t instanceIndex = instanceOffsets[instance_id];
     float4x4 transform = transforms[instanceIndex];

--- a/Sources/VimKitShaders/include/ShaderTypes.h
+++ b/Sources/VimKitShaders/include/ShaderTypes.h
@@ -33,22 +33,22 @@ typedef struct {
     Uniforms uniforms[2];
 } UniformsArray;
 
-// Instance Uniforms
+// Per Mesh Uniforms
 typedef struct {
-    int32_t identifier;
-    simd_float4x4 matrix;
     simd_float4 color;
     float glossiness;
     float smoothness;
-    bool xRay;
-} InstanceUniforms;
+} MeshUniforms;
 
 // Constants for the association of a specific buffer index argument passed into the shader function
 typedef NS_ENUM(EnumBackingType, BufferIndex) {
     BufferIndexPositions = 0,
     BufferIndexNormals = 1,
     BufferIndexUniforms = 2,
-    BufferIndexInstanceUniforms = 3,
+    BufferIndexMeshUniforms = 3,
+    BufferIndexTransforms = 4,
+    BufferIndexInstanceOffsets = 5,
+    BufferIndexXRay = 6
 };
 
 typedef NS_ENUM(EnumBackingType, VertexAttribute) {


### PR DESCRIPTION
# Description
Enables instancing in the `drawIndexedPrimitives(...)`  by adding `instanceCount` and `baseInstance` parameters when drawing submesh.

- Added the `Instanced` class that inverts the relationship between a `Mesh` and the `Instance`'s that share that `Mesh`.
- Added the MTLBuffer `transformsBuffer` that contains all of the Instance transforms.
- Added the MTLBuffer `instancedOffsetsBuffer` that contains all of the offsets into the `transformsBuffer` that can be accessed by the GPU inside the vertex shader.

Fixes #1 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
