### PR TITLE
Instancing

### DIFF
--- a/Sources/VimKit/Extensions/MTLBuffer+Extensions.swift
+++ b/Sources/VimKit/Extensions/MTLBuffer+Extensions.swift
@@ -19,11 +19,19 @@ public extension MTLBuffer {
     }
 
     /// Builds an UnsafeMutableBufferPointer from the buffer contents.
-    /// - Returns: a mutable buffer pointer of the specified type and
+    /// - Returns: a mutable buffer pointer of the specified type and length.
     func toUnsafeMutableBufferPointer<T>() -> UnsafeMutableBufferPointer<T> {
         let count = length/MemoryLayout<T>.stride
         let pointer: UnsafeMutablePointer<T> = contents().assumingMemoryBound(to: T.self)
         let bufferPointer = UnsafeMutableBufferPointer(start: pointer, count: count)
         return bufferPointer
+    }
+
+    /// Returns the buffer contents as mutable pointer of the specified type.
+    /// - Returns: a mutable pointer of the specified type and length.
+    func toUnsafeMutablePointer<T>() -> UnsafeMutablePointer<T> {
+        let count = length/MemoryLayout<T>.stride
+        let pointer: UnsafeMutablePointer<T> = contents().bindMemory(to: T.self, capacity: count)
+        return pointer
     }
 }

--- a/Sources/VimKit/Geometry+Mesh.swift
+++ b/Sources/VimKit/Geometry+Mesh.swift
@@ -11,16 +11,17 @@ extension Geometry {
 
     public class Instance {
 
-        /// The identifier of the instance
-        public let idenitifer: Int
-        /// 4x4 row-major matrix representing the node's world-space transform
-        public let matrix: float4x4
-        /// The first bit of each flag designates whether the instance should be initially hidden (1) or not (0) when rendered.
-        public let flags: Int16
+        /// Represents the state of the instance.
+        public enum State: Int {
+            case `default`
+            case hidden
+            case selected
+        }
+
+        /// The index of the instance
+        public let index: Int
         /// Marks the instance as hidden
-        public var hidden: Bool = false
-        /// Marks the instance as selected
-        public var selected: Bool = false
+        public var state: State = .default
         /// Flag indicating if the instance is transparent or not.
         public var transparent: Bool = false
         /// A reference to the parent instance
@@ -39,16 +40,13 @@ extension Geometry {
         /// Initializes the instance.
         /// 
         /// - Parameters:
-        ///   - identifier: the instance unique identifier. Use this to find instances
+        ///   - index: The instance index. Use this to find instances
         ///     within the geometry rather than the subscript as
         ///     the array of instances will most likely be sorted differently.
-        ///   - matrix: The 4x4 row-major matrix representing the node's world-space transform
         ///   - flags: Holds the flags for the given instance.
-        init(identifier: Int, matrix: float4x4 = .identity, flags: Int16) {
-            self.idenitifer = identifier
-            self.matrix = matrix
-            self.flags = flags
-            self.hidden = flags != .zero
+        init(index: Int, flags: Int16) {
+            self.index = index
+            self.state = flags != .zero ? .hidden : .default
         }
     }
 
@@ -67,6 +65,32 @@ extension Geometry {
         ///   - submeshes: The range of submeshes contained inside this mesh
         init(submeshes: Range<Int>? = nil) {
             self.submeshes = submeshes
+        }
+    }
+
+    /// Inverts the relationship between an Instance and a Mesh that allows us to draw using instancing.
+    class Instanced {
+
+        /// The mesh that is shared across the instances.
+        let mesh: Mesh
+        /// Flag indicating if the mesh is transparent or not
+        let transparent: Bool
+        /// The instance indexes.
+        let instances: [UInt32]
+        /// Provides an offset into the transforms buffer.
+        var baseInstance: Int
+
+        /// Initalizes the instanced mesh.
+        /// - Parameters:
+        ///   - mesh: the mesh that should be instanced
+        ///   - transparent: a flag indicating if the instance is transparent or not (used primarily for sorting).
+        ///   - instances: the instance indexes
+        ///   - baseInstance: the offset used by the GPU used to lookup the starting index into the transforms buffer.
+        init(mesh: Mesh, transparent: Bool, instances: [UInt32], _ baseInstance: Int = 0) {
+            self.mesh = mesh
+            self.transparent = transparent
+            self.instances = instances
+            self.baseInstance = baseInstance
         }
     }
 

--- a/Sources/VimKit/Geometry+Mesh.swift
+++ b/Sources/VimKit/Geometry+Mesh.swift
@@ -53,7 +53,7 @@ extension Geometry {
     }
 
     /// A mesh is composed of 0 or more submeshes.
-    public struct Mesh {
+    public struct Mesh: Equatable, Hashable {
 
         /// The range of submeshes contained inside this mesh.
         ///

--- a/Sources/VimKit/Geometry+Mesh.swift
+++ b/Sources/VimKit/Geometry+Mesh.swift
@@ -11,17 +11,12 @@ extension Geometry {
 
     public class Instance {
 
-        /// Represents the state of the instance.
-        public enum State: Int {
-            case `default`
-            case hidden
-            case selected
-        }
-
         /// The index of the instance
         public let index: Int
-        /// Marks the instance as hidden
-        public var state: State = .default
+        /// 4x4 row-major matrix representing the node's world-space transform
+        public let matrix: float4x4
+        /// The first bit of each flag designates whether the instance should be initially hidden (1) or not (0) when rendered.
+        public let flags: Int16
         /// Flag indicating if the instance is transparent or not.
         public var transparent: Bool = false
         /// A reference to the parent instance
@@ -43,10 +38,13 @@ extension Geometry {
         ///   - index: The instance index. Use this to find instances
         ///     within the geometry rather than the subscript as
         ///     the array of instances will most likely be sorted differently.
+        ///   - matrix: The 4x4 row-major matrix representing the node's world-space transform
         ///   - flags: Holds the flags for the given instance.
-        init(index: Int, flags: Int16) {
+        init(index: Int, matrix: float4x4, flags: Int16) {
             self.index = index
-            self.state = flags != .zero ? .hidden : .default
+            self.matrix = matrix
+            self.flags = flags
+            //self.state = flags != .zero ? .hidden : .default
         }
     }
 
@@ -69,7 +67,7 @@ extension Geometry {
     }
 
     /// Inverts the relationship between an Instance and a Mesh that allows us to draw using instancing.
-    class Instanced {
+    class InstancedMesh {
 
         /// The mesh that is shared across the instances.
         let mesh: Mesh

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -575,7 +575,7 @@ extension Geometry {
     ///   - ids: the ids of the instances to hide
     /// - Returns: the total count of hidden instances.
     public func hide(ids: [Int]) -> Int {
-        guard var pointer: UnsafeMutablePointer<Instances> = instancesBuffer?.toUnsafeMutablePointer() else { return 0 }
+        guard let pointer: UnsafeMutablePointer<Instances> = instancesBuffer?.toUnsafeMutablePointer() else { return 0 }
         for id in ids {
             guard let index = instanceOffsets.firstIndex(of: UInt32(id)) else { continue }
             pointer.advanced(by: index).pointee.state = .hidden
@@ -588,10 +588,10 @@ extension Geometry {
     ///   - id: the index of the instances to select or deselect
     /// - Returns: true if the instance was selected, otherwise false
     public func select(id: Int) -> Bool {
-        guard var pointer: UnsafeMutablePointer<Instances> = instancesBuffer?.toUnsafeMutablePointer(),
+        guard let pointer: UnsafeMutablePointer<Instances> = instancesBuffer?.toUnsafeMutablePointer(),
               let index = instanceOffsets.firstIndex(of: UInt32(id)) else { return false }
 
-        var instance = pointer[index]
+        let instance = pointer[index]
         switch instance.state {
         case .default, .hidden:
             pointer.advanced(by: index).pointee.state = .selected

--- a/Sources/VimKit/Renderer/VimRenderer+Drawing.swift
+++ b/Sources/VimKit/Renderer/VimRenderer+Drawing.swift
@@ -129,9 +129,9 @@ public extension VimRenderer {
         skycube?.draw(renderEncoder: renderEncoder)
     }
 
-    /// Draws instanced .
+    /// Draws an instanced mesh.
     /// - Parameters:
-    ///   - instanced: an instancing
+    ///   - instanced: the instanced mesh to draw
     ///   - renderEncoder: the render encoder
     private func drawInstanced(_ instanced: Geometry.InstancedMesh, renderEncoder: MTLRenderCommandEncoder) {
         guard let geometry, let range = instanced.mesh.submeshes else { return }

--- a/Sources/VimKit/Renderer/VimRenderer.swift
+++ b/Sources/VimKit/Renderer/VimRenderer.swift
@@ -140,13 +140,11 @@ extension VimRenderer {
             return
         }
         let id = Int(pixel)
-
         /// Raycast into the instance
         var point3D: SIMD3<Float> = .zero
         let query = camera.unprojectPoint(point)
         if let geometry,
-           let instance = geometry.instance(for: id),
-           let result = instance.raycast(geometry, query: query) {
+           let result = geometry.instances[id].raycast(geometry, query: query) {
             point3D = result.position
         }
         // Select the instance so the event gets published.

--- a/Sources/VimKit/Vim.swift
+++ b/Sources/VimKit/Vim.swift
@@ -214,9 +214,7 @@ public class Vim: NSObject, ObservableObject {
             assert(false, "The geometry block is absent")
             return
         }
-        assert(geometry.instanceTransforms.count == count, "The number of transforms doesn't match the instance count.")
-        assert(geometry.instanceParents.count == count, "The number of instance parents doesn't match the instance count.")
-        assert(geometry.instanceMeshes.count == count, "The number of instance meshes doesn't match the instance count.")
+        assert(geometry.transforms.count == count, "The number of transforms doesn't match the instance count.")
 
         guard let materialsTable = db?.Material else {
             assert(false, "The materials table doesn't exist in the database")

--- a/Sources/VimKit/Vim.swift
+++ b/Sources/VimKit/Vim.swift
@@ -214,7 +214,6 @@ public class Vim: NSObject, ObservableObject {
             assert(false, "The geometry block is absent")
             return
         }
-        assert(geometry.transforms.count == count, "The number of transforms doesn't match the instance count.")
 
         guard let materialsTable = db?.Material else {
             assert(false, "The materials table doesn't exist in the database")
@@ -284,17 +283,12 @@ extension Vim {
     ///   - id: the id of the instance to select (or deselect if already selected).
     ///   - point: the point in 3D space where the object was selected
     public func select(id: Int, point: SIMD3<Float> = .zero) {
-        // Find the instance by it's id, not subscript as the instances have been sorted.
-        guard let geometry, let instance = geometry.instance(for: id) else { return }
-
-        switch instance.state {
-        case .default, .hidden:
-            instance.state = .selected
-        case .selected:
-            instance.state = .default
+        guard let geometry else { return }
+        let selected = geometry.select(id: id)
+        DispatchQueue.main.async {
+            // Publish the selection event
+            self.eventPublisher.send(.selected(id, selected, 1, point))
         }
-        // Publish the selection event
-        eventPublisher.send(.selected(id, instance.state == .selected, geometry.selectedCount, point))
     }
 
     /// Toggles an instance hidden state for the instance with the specified id
@@ -303,25 +297,20 @@ extension Vim {
     ///   - id: the ids of the instances to hide
     public func hide(ids: [Int]) async {
         guard let geometry else { return }
-        for id in ids {
-            guard let instance = geometry.instance(for: id) else { continue }
-            instance.state = .hidden
-        }
+        let hiddenCount = geometry.hide(ids: ids)
         DispatchQueue.main.async {
             // Publish the hidden event
-            self.eventPublisher.send(.hidden(geometry.hiddenCount))
+            self.eventPublisher.send(.hidden(hiddenCount))
         }
     }
 
     /// Unhides all hidden instances.
     public func unhide() async {
         guard let geometry else { return }
-        geometry.instances.filter{ $0.state == .hidden }.forEach { instance in
-            instance.state = .default
-        }
+        geometry.unhide()
         DispatchQueue.main.async {
             // Publish the hidden event
-            self.eventPublisher.send(.hidden(geometry.hiddenCount))
+            self.eventPublisher.send(.hidden(0))
         }
     }
 }

--- a/Sources/VimKitShaders/Resources/Shaders.metal
+++ b/Sources/VimKitShaders/Resources/Shaders.metal
@@ -55,7 +55,16 @@ typedef struct {
     int32_t index [[color(1)]];
 } ColorOut;
 
-// The main vertex shader function
+// The main vertex shader function.
+// - Parameters:
+//   - in: The vertex position + normal data.
+//   - amp_id: The index into the uniforms array used for stereoscopic views in visionOS.
+//   - instance_id: The baseInstance parameter passed to the draw call used to map this instance to it's transform data.
+//   - uniformsArray: The per frame uniforms.
+//   - meshUniforms: The per mesh uniforms.
+//   - transforms: The instance transform matrices.
+//   - instanceOffsets: The current instance index into the transforms pointer.
+//   - xRay: Flag indicating if this frame is being rendered in xray mode.
 vertex VertexOut vertexMain(Vertex in [[stage_in]],
                             ushort amp_id [[amplification_id]],
                             uint vertex_id [[vertex_id]],
@@ -106,7 +115,11 @@ vertex VertexOut vertexMain(Vertex in [[stage_in]],
     return out;
 }
 
-// The primary fragment shader function that includes the texture
+// The main fragment shader function.
+// - Parameters:
+//   - in: the data passed from the vertex function.
+//   - texture: the texture.
+//   - colorSampler: The color sampler.
 fragment ColorOut fragmentMain(VertexOut in [[stage_in]],
                               texture2d<float, access::sample> texture [[texture(0)]],
                               sampler colorSampler [[sampler(0)]]) {

--- a/Sources/VimKitShaders/Resources/Shaders.metal
+++ b/Sources/VimKitShaders/Resources/Shaders.metal
@@ -101,19 +101,22 @@ vertex VertexOut vertexMain(Vertex in [[stage_in]],
     out.smoothness = meshUniforms.smoothness;
     out.color = meshUniforms.color;
     
-    switch(instance.state) {
-        case InstanceStateDefault:
-            break;
-        case InstanceStateSelected:
-            out.color = selectionColor; //float4(0.0, 0.0, 1.0, 1.0);
-            break;
-    }
-
     // XRay the object
     if (xRay) {
         float grayscale = 0.299 * meshUniforms.color.x + 0.587 * meshUniforms.color.y + 0.114 * meshUniforms.color.z;
         float alpha = meshUniforms.color.w * 0.1;
         out.color = float4(grayscale, grayscale, grayscale, alpha);
+    }
+    
+    // Override the color based on the instance state
+    switch (instance.state) {
+        case InstanceStateDefault:
+            break;
+        case InstanceStateHidden:
+            break;
+        case InstanceStateSelected:
+            out.color = selectionColor;
+            break;
     }
 
     // Pass lighting information to the fragment shader

--- a/Sources/VimKitShaders/Resources/Shaders.metal
+++ b/Sources/VimKitShaders/Resources/Shaders.metal
@@ -69,11 +69,11 @@ vertex VertexOut vertexMain(Vertex in [[stage_in]],
                             ushort amp_id [[amplification_id]],
                             uint vertex_id [[vertex_id]],
                             uint instance_id [[instance_id]],
-                            constant UniformsArray &uniformsArray [[ buffer(BufferIndexUniforms) ]],
-                            constant MeshUniforms &meshUniforms [[ buffer(BufferIndexMeshUniforms) ]],
-                            constant float4x4 *transforms [[ buffer(BufferIndexTransforms) ]],
-                            constant uint32_t *instanceOffsets [[ buffer(BufferIndexInstanceOffsets) ]],
-                            constant bool &xRay [[ buffer(BufferIndexXRay) ]]) {
+                            constant UniformsArray &uniformsArray [[buffer(BufferIndexUniforms)]],
+                            constant MeshUniforms &meshUniforms [[buffer(BufferIndexMeshUniforms)]],
+                            constant float4x4 *transforms [[buffer(BufferIndexTransforms)]],
+                            constant uint32_t *instanceOffsets [[buffer(BufferIndexInstanceOffsets)]],
+                            constant bool &xRay [[buffer(BufferIndexXRay)]]) {
 
     uint32_t instanceIndex = instanceOffsets[instance_id];
     float4x4 transform = transforms[instanceIndex];

--- a/Sources/VimKitShaders/include/ShaderTypes.h
+++ b/Sources/VimKitShaders/include/ShaderTypes.h
@@ -33,22 +33,22 @@ typedef struct {
     Uniforms uniforms[2];
 } UniformsArray;
 
-// Instance Uniforms
+// Per Mesh Uniforms
 typedef struct {
-    int32_t identifier;
-    simd_float4x4 matrix;
     simd_float4 color;
     float glossiness;
     float smoothness;
-    bool xRay;
-} InstanceUniforms;
+} MeshUniforms;
 
 // Constants for the association of a specific buffer index argument passed into the shader function
 typedef NS_ENUM(EnumBackingType, BufferIndex) {
     BufferIndexPositions = 0,
     BufferIndexNormals = 1,
     BufferIndexUniforms = 2,
-    BufferIndexInstanceUniforms = 3,
+    BufferIndexMeshUniforms = 3,
+    BufferIndexTransforms = 4,
+    BufferIndexInstanceOffsets = 5,
+    BufferIndexXRay = 6
 };
 
 typedef NS_ENUM(EnumBackingType, VertexAttribute) {

--- a/Sources/VimKitShaders/include/ShaderTypes.h
+++ b/Sources/VimKitShaders/include/ShaderTypes.h
@@ -40,14 +40,28 @@ typedef struct {
     float smoothness;
 } MeshUniforms;
 
-// Constants for the association of a specific buffer index argument passed into the shader function
+// Enum constants for possible instance states
+typedef NS_ENUM(EnumBackingType, InstanceState) {
+    InstanceStateDefault = 0,
+    InstanceStateHidden = 1,
+    InstanceStateSelected = 2,
+};
+
+// Instancing Data
+typedef struct {
+    uint32_t index;
+    simd_float4x4 matrix;
+    InstanceState state;
+} Instances;
+
+// Enum constants for the association of a specific buffer index argument passed into the shader function
 typedef NS_ENUM(EnumBackingType, BufferIndex) {
     BufferIndexPositions = 0,
     BufferIndexNormals = 1,
     BufferIndexUniforms = 2,
     BufferIndexMeshUniforms = 3,
-    BufferIndexTransforms = 4,
-    BufferIndexInstanceOffsets = 5,
+    BufferIndexInstances = 4,
+    BufferIndexSelectionColor = 5,
     BufferIndexXRay = 6
 };
 


### PR DESCRIPTION
# Description
Enables instancing in the `drawIndexedPrimitives(...)`  by adding `instanceCount` and `baseInstance` parameters when drawing submesh.

- Added the `InstancedMesh` class that inverts the relationship between a `Mesh` and the `Instance`'s that share that `Mesh`.
- Added the MTLBuffer `instancesBuffer` that contains all of the Instance data.

Fixes #1 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
