### PR TITLE
MTLBuffer (bytesNoCopy) Fix

### DIFF
--- a/Sources/VimKit/BFast.swift
+++ b/Sources/VimKit/BFast.swift
@@ -8,9 +8,6 @@
 import CryptoKit
 import Foundation
 
-/// The min data size (in MB) used to determine if a data block should be mmap'd or not.
-private let minMmapByteSize = 1024 * 1000 * 64
-
 /// The BFast format is essentially a collection of named data buffers (byte arrays).
 struct BFast: Hashable {
 
@@ -183,7 +180,7 @@ struct BFast: Hashable {
             } else {
                 let name = names[i-1]
                 // Mmap the data slice to it's own file
-                if slice.count >= minMmapByteSize {
+                if slice.count >= Data.minMmapByteSize {
                     guard let b = Buffer(data: slice, sha256Hash, name) else { continue }
                     buffers.append(b)
                 } else {

--- a/Sources/VimKit/Extensions/Data+Extensions.swift
+++ b/Sources/VimKit/Extensions/Data+Extensions.swift
@@ -10,6 +10,9 @@ import Foundation
 
 extension Data {
 
+    /// The min data size (in MB) used to determine if a data block should be mmap'd or not.
+    static let minMmapByteSize = 1024 * 1000 * 8
+
     /// Calculates the SHA hash of this data
     var sha256Hash: String {
         let hashed = SHA256.hash(data: self)

--- a/Sources/VimKit/Geometry+Attribute.swift
+++ b/Sources/VimKit/Geometry+Attribute.swift
@@ -26,17 +26,28 @@ extension Geometry {
 
 extension Array where Element == Geometry.Attribute {
 
-    func makeBufferNoCopy<T>(device: MTLDevice, type: T.Type) -> MTLBuffer? {
+
+    /// Helper method that creates a MTLBuffer from the array data.
+    /// - Parameters:
+    ///   - device: the metal device
+    ///   - type: the data type
+    /// - Returns: a new MTLBuffer that is either made from copy or no-copy depending on the data size and count.
+    func makeBuffer<T>(device: MTLDevice, type: T.Type) -> MTLBuffer? {
         guard self.isNotEmpty else { return nil }
+        var buffer = data
         if self.count > 1 {
-            var buffer = data
+            // If we have a combined data block, we'll need to copy the bytes :(
+            return device.makeBuffer(data, type: type)
+        }
+
+        if buffer.count >= Data.minMmapByteSize {
+            // Make the buffer without copying the bytes
             return device.makeBufferNoCopy(&buffer, type: type)
         } else {
-            // Handle a single element array
-            let attribute = self[0]
-            var data = attribute.buffer.data
-            return device.makeBufferNoCopy(&data, attribute.buffer.name, type: type)
+            // Simply build a buffer by copying the bytes
+            return device.makeBuffer(data, type: type)
         }
+        return nil
     }
 
     /// Helper method that converts an array of attributes to data,

--- a/Sources/VimKit/Geometry+Mesh.swift
+++ b/Sources/VimKit/Geometry+Mesh.swift
@@ -44,7 +44,6 @@ extension Geometry {
             self.index = index
             self.matrix = matrix
             self.flags = flags
-            //self.state = flags != .zero ? .hidden : .default
         }
     }
 

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -28,7 +28,7 @@ public class Geometry: ObservableObject {
     }
 
     /// Progress Reporting for loading the geometry data.
-    @objc public dynamic let progress = Progress(totalUnitCount: 9)
+    public dynamic let progress = Progress(totalUnitCount: 9)
 
     @Published
     public var state: State = .loading
@@ -78,7 +78,7 @@ public class Geometry: ObservableObject {
 
         // 1) Build the positions (vertex) buffer
         let positions = attributes(association: .vertex, semantic: .position)
-        guard let positionsBuffer = positions.makeBufferNoCopy(device: device, type: Float.self) else {
+        guard let positionsBuffer = positions.makeBuffer(device: device, type: Float.self) else {
             fatalError("💀 Unable to create positions buffer")
         }
         self.positionsBuffer = positionsBuffer
@@ -86,7 +86,7 @@ public class Geometry: ObservableObject {
 
         // 2) Build the index buffer
         let indices = attributes(association: .corner, semantic: .index)
-        guard let indexBuffer = indices.makeBufferNoCopy(device: device, type: UInt32.self) else {
+        guard let indexBuffer = indices.makeBuffer(device: device, type: UInt32.self) else {
             fatalError("💀 Unable to create index buffer")
         }
         self.indexBuffer = indexBuffer

--- a/Sources/VimKit/Renderer/VimRenderer+Drawing.swift
+++ b/Sources/VimKit/Renderer/VimRenderer+Drawing.swift
@@ -55,9 +55,6 @@ public extension VimRenderer {
         // Update the per-frame uniforms
         updateUniforms()
 
-        // Encode the uniforms to send to the vertex function
-        renderEncoder.setVertexBuffer(uniformBuffer, offset: uniformBufferOffset, index: .uniforms)
-
         // Perform any pre scene draws
         willDrawScene(renderEncoder: renderEncoder)
 
@@ -90,6 +87,7 @@ public extension VimRenderer {
         renderEncoder.setTriangleFillMode(fillMode)
 
         // Setup the per frame buffers to pass to the GPU
+        renderEncoder.setVertexBuffer(uniformBuffer, offset: uniformBufferOffset, index: .uniforms)
         renderEncoder.setVertexBuffer(positionsBuffer, offset: 0, index: .positions)
         renderEncoder.setVertexBuffer(normalsBuffer, offset: 0, index: .normals)
         renderEncoder.setVertexBuffer(instancesBuffer, offset: 0, index: .instances)

--- a/Sources/VimKit/Vim.swift
+++ b/Sources/VimKit/Vim.swift
@@ -59,7 +59,7 @@ public class Vim: NSObject, ObservableObject {
     public lazy var events = eventPublisher.eraseToAnyPublisher()
 
     /// Progress Reporting for reading, mapping, and indexing the file.
-    @objc public dynamic let progress = Progress(totalUnitCount: 5)
+    public dynamic let progress = Progress(totalUnitCount: 5)
 
     /// See: https://github.com/vimaec/vim#header-buffer
     public var header = [String: String]()
@@ -189,9 +189,6 @@ public class Vim: NSObject, ObservableObject {
                 break
             }
         }
-
-        // Validate the file
-//        validate()
 
         debugPrint("􀇺 [Vim] - validated [\(bfast.header)]")
 


### PR DESCRIPTION
# Description

Fixes the issue when trying to create an MTLBuffer `(bytesNoCopy)` from data that wasn't mapped to a file. Added simple check to see if the data block was mapped an introduced path to build the MTLBuffer by copying the bytes if below the size threshold.

Fixes #19 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
