### PR TITLE
Calculate Vertex Normals on GPU

### DIFF
--- a/Sources/VimKit/Database+Importer.swift
+++ b/Sources/VimKit/Database+Importer.swift
@@ -336,15 +336,3 @@ extension Database {
         }
     }
 }
-
-extension TimeInterval {
-
-    func stringFromTimeInterval() -> String {
-        let time = Int(self)
-        let ms = Int((self.truncatingRemainder(dividingBy: 1)) * 1000)
-        let seconds = time % 60
-        let minutes = (time / 60) % 60
-        let hours = (time / 3600)
-        return String(format: "%0.2d:%0.2d:%0.2d.%0.3d", hours, minutes, seconds, ms)
-    }
-}

--- a/Sources/VimKit/Extensions/TimeInterval+Extensions.swift
+++ b/Sources/VimKit/Extensions/TimeInterval+Extensions.swift
@@ -1,0 +1,20 @@
+//
+//  TimeInterval+Extensions.swift
+//
+//
+//  Created by Kevin McKee
+//
+
+import Foundation
+
+extension TimeInterval {
+
+    func stringFromTimeInterval() -> String {
+        let time = Int(self)
+        let ms = Int((self.truncatingRemainder(dividingBy: 1)) * 1000)
+        let seconds = time % 60
+        let minutes = (time / 60) % 60
+        let hours = (time / 3600)
+        return String(format: "%0.2d:%0.2d:%0.2d.%0.3d", hours, minutes, seconds, ms)
+    }
+}

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -10,6 +10,8 @@ import MetalKit
 import simd
 import VimKitShaders
 
+// The MPS function name for computing the vertex normals on the GPU
+private let computeVertexNormalsFunctionName = "computeVertexNormals"
 // File extensions for mmap'd metal buffers
 private let normalsBufferExtension = ".normals"
 
@@ -93,18 +95,10 @@ public class Geometry: ObservableObject {
         progress.completedUnitCount += 1
 
         // 3) Build the normals buffer
-        let normalsBufferFile = cacheDir.appending(path: "\(bfast.sha256Hash)\(normalsBufferExtension)")
-        if !FileManager.default.fileExists(atPath: normalsBufferFile.path) {
-            var normals = vertexNormals
-            let data = Data(bytes: &normals, count: MemoryLayout<Float>.size * normals.count)
-            try! data.write(to: normalsBufferFile)
+        Task {
+            await computeVertexNormals(device: device, cacheDirectory: cacheDir)
+            progress.completedUnitCount += 1
         }
-
-        guard let normalsBuffer = device.makeBufferNoCopy(normalsBufferFile, type: Float.self) else {
-            fatalError("💀 Unable to create normals buffer")
-        }
-        self.normalsBuffer = normalsBuffer
-        progress.completedUnitCount += 1
 
         // 4) Build all the data structures
         _ = materials // Build the materials
@@ -162,6 +156,77 @@ public class Geometry: ObservableObject {
     }()
 
     // MARK: Vertices
+
+    /// Computes the vertiex normals on the GPU using Metal Performance Shaders.
+    /// - Parameters:
+    ///   - device: the metal device to use
+    ///   - cacheDirectory: the cache directory
+    private func computeVertexNormals(device: MTLDevice, cacheDirectory: URL) async {
+
+        let start = Date.now
+        defer {
+            let timeInterval = abs(start.timeIntervalSinceNow)
+            debugPrint("􀬨 Normals computed in [\(timeInterval.stringFromTimeInterval())]")
+        }
+
+        // If the normals file has already been generated, just make the MTLBuffer from it
+        let normalsBufferFile = cacheDirectory.appending(path: "\(bfast.sha256Hash)\(normalsBufferExtension)")
+        if FileManager.default.fileExists(atPath: normalsBufferFile.path) {
+            guard let normalsBuffer = device.makeBufferNoCopy(normalsBufferFile, type: Float.self) else {
+                fatalError("💀 Unable to make MTLBuffer from normals file.")
+            }
+            self.normalsBuffer = normalsBuffer
+            return
+        }
+
+        let commandQueue = device.makeCommandQueue()
+        var positionsCount = positions.count
+        var indicesCount = indices.count
+
+        guard let library = MTLContext.makeLibrary(),
+              let function = library.makeFunction(name: computeVertexNormalsFunctionName),
+              let pipelineState = await try? device.makeComputePipelineState(function: function),
+              let positionsBuffer,
+              let indexBuffer,
+              let faceNormalsBuffer = device.makeBuffer(
+                length: MemoryLayout<SIMD3<Float>>.stride * (positionsCount/3),
+                options: [.storageModeShared]),
+              let resultsBuffer = device.makeBuffer(
+                length: MemoryLayout<Float>.stride * positionsCount,
+                options: [.storageModeShared]),
+              let commandBuffer = commandQueue?.makeCommandBuffer(),
+              let computeEncoder = commandBuffer.makeComputeCommandEncoder() else {
+            fatalError("💩 Unable to compute normals.")
+        }
+
+        computeEncoder.setComputePipelineState(pipelineState)
+
+        // Encode the buffers to pass to the GPU
+        computeEncoder.setBuffer(positionsBuffer, offset: 0, index: 0)
+        computeEncoder.setBuffer(indexBuffer, offset: 0, index: 1)
+        computeEncoder.setBuffer(faceNormalsBuffer, offset: 0, index: 2)
+        computeEncoder.setBuffer(resultsBuffer, offset: 0, index: 3)
+        computeEncoder.setBytes(&positionsCount, length: MemoryLayout<Int>.size, index: 4)
+        computeEncoder.setBytes(&indicesCount, length: MemoryLayout<Int>.size, index: 5)
+
+        // Set the thread group size and dispatch
+        let gridSize = MTLSizeMake(1, 1, 1);
+        let maxThreadsPerGroup = pipelineState.maxTotalThreadsPerThreadgroup
+        let threadgroupSize = MTLSizeMake(maxThreadsPerGroup, 1, 1);
+        computeEncoder.dispatchThreadgroups(gridSize, threadsPerThreadgroup: threadgroupSize)
+
+        computeEncoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+
+        // Finally, write the results to a cache file and create the MTLBuffer from it
+        let data = Data(bytes: resultsBuffer.contents(), count: resultsBuffer.length)
+        try? data.write(to: normalsBufferFile)
+        guard let normalsBuffer = device.makeBufferNoCopy(normalsBufferFile, type: Float.self) else {
+            fatalError("💀 Unable to make MTLBuffer from normals file.")
+        }
+        self.normalsBuffer = resultsBuffer
+    }
 
     /// Calculates the vertex normals.
     /// TODO: Port this over to Metal Performance Shaders to perform this work on the GPU.

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -185,7 +185,7 @@ public class Geometry: ObservableObject {
 
         guard let library = MTLContext.makeLibrary(),
               let function = library.makeFunction(name: computeVertexNormalsFunctionName),
-              let pipelineState = await try? device.makeComputePipelineState(function: function),
+              let pipelineState = try? await device.makeComputePipelineState(function: function),
               let positionsBuffer,
               let indexBuffer,
               let faceNormalsBuffer = device.makeBuffer(
@@ -225,7 +225,7 @@ public class Geometry: ObservableObject {
         guard let normalsBuffer = device.makeBufferNoCopy(normalsBufferFile, type: Float.self) else {
             fatalError("💀 Unable to make MTLBuffer from normals file.")
         }
-        self.normalsBuffer = resultsBuffer
+        self.normalsBuffer = normalsBuffer
     }
 
     /// Calculates the vertex normals.
@@ -233,6 +233,7 @@ public class Geometry: ObservableObject {
     /// - https://computergraphics.stackexchange.com/questions/4031/programmatically-generating-vertex-normals
     /// -  https://iquilezles.org/articles/normals/
     /// - Returns: an array of vertex normals
+    @available(*, deprecated, message: "Use computeVertexNormals(device:cacheDirectory) to build vertex normals.")
     var vertexNormals: [Float] {
         var results = [Float]()
         for normal in faceNormals {
@@ -279,6 +280,7 @@ public class Geometry: ObservableObject {
 
     /// If not provided, will be computed dynamically as the average of all vertex normals,
     /// NOTE: This is not lazy as we can truly discard it from memory once done with it.
+    @available(*, deprecated, message: "Use computeVertexNormals(device:cacheDirectory) to build vertex normals.")
     var faceNormals: [SIMD3<Float>] {
         var results = [SIMD3<Float>]()
         let attributes = attributes(association: .face, semantic: .normal)
@@ -304,7 +306,6 @@ public class Geometry: ObservableObject {
             }
             results.append(contentsOf: faceNormals)
         }
-
         return results
     }
 

--- a/Sources/VimKitShaders/Resources/Compute.metal
+++ b/Sources/VimKitShaders/Resources/Compute.metal
@@ -6,9 +6,7 @@
 //
 
 #include <metal_stdlib>
-#include <simd/simd.h>
 using namespace metal;
-
 
 // Computes the vertex normals.
 // See: https://iquilezles.org/articles/normals/
@@ -20,10 +18,10 @@ using namespace metal;
 //   - normals: The pointer to the normals that will be updated with the computed values.
 //   - positionsCount: The count of positions.
 //   - indicesCount: The count of indices.
-kernel void computeVertexNormals(device const float* positions,
-                           device const uint32_t* indices,
-                           device float3* faceNormals,
-                           device float* normals,
+kernel void computeVertexNormals(device const float *positions,
+                           device const uint32_t *indices,
+                           device float3 *faceNormals,
+                           device float *normals,
                            constant int &positionsCount,
                            constant int &indicesCount) {
     

--- a/Sources/VimKitShaders/Resources/Compute.metal
+++ b/Sources/VimKitShaders/Resources/Compute.metal
@@ -1,0 +1,54 @@
+//
+//  Compute.metal
+//
+//
+//  Created by Kevin McKee
+//
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+using namespace metal;
+
+
+// Computes the vertex normals.
+// See: https://iquilezles.org/articles/normals/
+// See: https://computergraphics.stackexchange.com/questions/4031/programmatically-generating-vertex-normals
+// - Parameters:
+//   - positions: The pointer to the positions.
+//   - indices: The pointer to the indices.
+//   - faceNormals: The pointer to the face normals that will be updated with computed values.
+//   - normals: The pointer to the normals that will be updated with the computed values.
+//   - positionsCount: The count of positions.
+//   - indicesCount: The count of indices.
+kernel void computeVertexNormals(device const float* positions,
+                           device const uint32_t* indices,
+                           device float3* faceNormals,
+                           device float* normals,
+                           constant int &positionsCount,
+                           constant int &indicesCount) {
+    
+    const int verticesCount = positionsCount / 3;
+    
+    // 1) Calculate the face normals
+    for (int i = 0; i < indicesCount; i += 3) {
+        int j = indices[i] * 3;
+        const float3 a = float3(positions[j], positions[j+1], positions[j+2]);
+        j = indices[i+1] * 3;
+        const float3 b = float3(positions[j], positions[j+1], positions[j+2]);
+        j = indices[i+2] * 3;
+        const float3 c = float3(positions[j], positions[j+1], positions[j+2]);
+        const float3 crossProduct = cross(b - a, c - a);
+        faceNormals[indices[i]] += crossProduct;
+        faceNormals[indices[i+1]] += crossProduct;
+        faceNormals[indices[i+2]] += crossProduct;
+    }
+
+    // 2) Calculate the vertex normals
+    for (int i = 0; i < verticesCount; i++) {
+        int j = i * 3;
+        const float3 n = normalize(faceNormals[i]);
+        normals[j] = n.x;
+        normals[j+1] = n.y;
+        normals[j+2] = n.z;
+    }
+}

--- a/Sources/VimKitShaders/Resources/Shaders.metal
+++ b/Sources/VimKitShaders/Resources/Shaders.metal
@@ -20,7 +20,7 @@ constant float4 materialSpecularColor = float4(1.0, 1.0, 1.0, 1.0);
 // The struct that is passed to the vertex function
 typedef struct {
     // 3D coordinates representing a position in space
-    simd_float3 position [[attribute(VertexAttributePosition)]];
+    float3 position [[attribute(VertexAttributePosition)]];
     // Used for lighting calculations (such as Phong shading)
     float3 normal [[attribute(VertexAttributeNormal)]];
 } Vertex;
@@ -28,17 +28,17 @@ typedef struct {
 // The struct that is passed from the vertex function to the fragment function
 typedef struct {
     // The position of the vertex
-    simd_float4 position [[position]];
+    float4 position [[position]];
     // The normal from the perspective of the camera
-    simd_float3 cameraNormal;
+    float3 cameraNormal;
     // The directional vector from the perspective of the camera
-    simd_float3 cameraDirection;
+    float3 cameraDirection;
     // The direction of the light from the position of the camera
-    simd_float3 cameraLightDirection;
+    float3 cameraLightDirection;
     // The distance from camera to the vertex
     float cameraDistance;
     // The material color
-    simd_float4 color;
+    float4 color;
     // The material glossiness
     float glossiness;
     // The material smoothness
@@ -85,11 +85,11 @@ vertex VertexOut vertexMain(Vertex in [[stage_in]],
     
     Uniforms uniforms = uniformsArray.uniforms[amp_id];
 
-    simd_float4x4 modelMatrix = instance.matrix;
-    simd_float4x4 viewMatrix = uniforms.viewMatrix;
-    simd_float4x4 projectionMatrix = uniforms.projectionMatrix;
-    simd_float4x4 modelViewProjectionMatrix = projectionMatrix * viewMatrix * modelMatrix;
-    simd_float4x4 modelViewMatrix = viewMatrix * modelMatrix;
+    float4x4 modelMatrix = instance.matrix;
+    float4x4 viewMatrix = uniforms.viewMatrix;
+    float4x4 projectionMatrix = uniforms.projectionMatrix;
+    float4x4 modelViewProjectionMatrix = projectionMatrix * viewMatrix * modelMatrix;
+    float4x4 modelViewMatrix = viewMatrix * modelMatrix;
 
     // Position
     float4 position = float4(in.position, 1.0);

--- a/Sources/VimKitShaders/Resources/Skycube.metal
+++ b/Sources/VimKitShaders/Resources/Skycube.metal
@@ -6,7 +6,6 @@
 //
 
 #include <metal_stdlib>
-#include <simd/simd.h>
 #include "../include/ShaderTypes.h"
 
 using namespace metal;
@@ -19,9 +18,9 @@ typedef struct {
 // The struct that is passed from the vertex function to the fragment function
 typedef struct {
     // The position of the vertex
-    simd_float4 position [[position]];
+    float4 position [[position]];
     // The material color
-    simd_float4 color;
+    float4 color;
     // The texture coordinates
     float3 textureCoordinates;
     // The instance identifier
@@ -42,12 +41,12 @@ vertex VertexOut vertexSkycube(VertexIn in [[stage_in]],
                               ushort amp_id [[amplification_id]]) {
     
     Uniforms uniforms = uniformsArray.uniforms[amp_id];
-    simd_float4x4 projectionMatrix = uniforms.projectionMatrix;
+    float4x4 projectionMatrix = uniforms.projectionMatrix;
 
-    simd_float4x4 viewMatrix = uniforms.viewMatrix;
+    float4x4 viewMatrix = uniforms.viewMatrix;
     viewMatrix[3] = float4(0, 0, 0, 1);
 
-    simd_float4x4 viewProjectionMatrix = viewMatrix * projectionMatrix;
+    float4x4 viewProjectionMatrix = viewMatrix * projectionMatrix;
     
     VertexOut out;
     out.position = (viewProjectionMatrix * in.position).xyww;


### PR DESCRIPTION
# Description

Adds the [MPS](https://developer.apple.com/documentation/metalperformanceshaders) kernel `computeVertexNormals(...)` that calculates the entire vertex normals buffer on the GPU instead of performing that work on the CPU.

**Before (on CPU)**:
`Normals computed in [00:00:14.974]`

**After (on GPU)**: 
`Normals computed in [00:00:05.098]`

**After (on GPU) with caching**: 
`Normals computed in [00:00:00.002]`

Fixes #24 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
