### PR TITLE
Shared Metal Structures

### DIFF
--- a/Sources/VimKitShaders/Resources/Shapes.metal
+++ b/Sources/VimKitShaders/Resources/Shapes.metal
@@ -9,17 +9,6 @@
 #include "../include/ShaderTypes.h"
 using namespace metal;
 
-// The struct that is passed to the shape vertex function
-typedef struct {
-    float3 position [[attribute(VertexAttributePosition)]];
-} ShapeIn;
-
-// The struct that is passed from the shape vertex function to the fragment function
-struct ShapeOut {
-    float4 position [[position]];
-    float4 color;
-};
-
 // The shape vertex shader function.
 // - Parameters:
 //   - in: The vertex position data.
@@ -30,21 +19,20 @@ struct ShapeOut {
 //   - color: The shape color.
 //   - colorOverrides: The color overrides pointer used to apply custom color profiles to instances.
 //   - xRay: Flag indicating if this frame is being rendered in xray mode.
-vertex ShapeOut vertexShape(ShapeIn in [[stage_in]],
-                            ushort amp_id [[amplification_id]],
-                            uint vertex_id [[vertex_id]],
-                            constant UniformsArray &uniformsArray [[ buffer(VertexBufferIndexUniforms) ]],
-                            constant float4x4 &modelMatrix [[buffer(VertexBufferIndexInstances)]],
-                            constant float4 &color [[buffer(VertexBufferIndexColors)]]) {
-    ShapeOut out;
+vertex VertexOut vertexShape(VertexIn in [[stage_in]],
+                             ushort amp_id [[amplification_id]],
+                             uint vertex_id [[vertex_id]],
+                             constant UniformsArray &uniformsArray [[ buffer(VertexBufferIndexUniforms) ]],
+                             constant float4x4 &modelMatrix [[buffer(VertexBufferIndexInstances)]],
+                             constant float4 &color [[buffer(VertexBufferIndexColors)]]) {
+    VertexOut out;
     Uniforms uniforms = uniformsArray.uniforms[amp_id];
     float4x4 viewMatrix = uniforms.viewMatrix;
     float4x4 projectionMatrix = uniforms.projectionMatrix;
     float4x4 modelViewProjectionMatrix = projectionMatrix * viewMatrix * modelMatrix;
 
     // Position
-    float4 position = float4(in.position, 1.0);
-    out.position = modelViewProjectionMatrix * position;
+    out.position = modelViewProjectionMatrix * in.position;
     // Color
     out.color = color;
     return out;
@@ -53,7 +41,7 @@ vertex ShapeOut vertexShape(ShapeIn in [[stage_in]],
 // The shape fragment shader function.
 // - Parameters:
 //   - in: the data passed from the vertex function.
-fragment float4 fragmentShape(ShapeOut in [[stage_in]]) {
+fragment float4 fragmentShape(VertexOut in [[stage_in]]) {
     return in.color;
 }
 

--- a/Sources/VimKitShaders/Resources/Skycube.metal
+++ b/Sources/VimKitShaders/Resources/Skycube.metal
@@ -10,39 +10,14 @@
 
 using namespace metal;
 
-// The struct that is passed to the vertex function
-typedef struct {
-    float4 position [[attribute(VertexAttributePosition)]];
-} SkyCubeIn;
-
-// The struct that is passed from the vertex function to the fragment function
-typedef struct {
-    // The position of the vertex
-    float4 position [[position]];
-    // The material color
-    float4 color;
-    // The texture coordinates
-    float3 textureCoordinates;
-    // The instance index (-1 indicates a non-selectable or invalid instance)
-    int32_t index;
-} SkyCubeOut;
-
-// The struct that is returned from the fragment function
-typedef struct {
-    // The colorAttachments[0] that holds the color information
-    float4 color [[color(0)]];
-    // The colorAttachments[1] that holds the instance index (-1 indicates a non-selectable or invalid instance)
-    int32_t index [[color(1)]];
-} ColorOut;
-
 // The skycube vertex shader function.
 // - Parameters:
 //   - in: The vertex position data.
 //   - amp_id: The index into the uniforms array used for stereoscopic views in visionOS.
 //   - uniformsArray: The per frame uniforms.
-vertex SkyCubeOut vertexSkycube(SkyCubeIn in [[stage_in]],
-                                ushort amp_id [[amplification_id]],
-                                constant UniformsArray &uniformsArray [[ buffer(VertexBufferIndexUniforms) ]]) {
+vertex VertexOut vertexSkycube(VertexIn in [[stage_in]],
+                               ushort amp_id [[amplification_id]],
+                               constant UniformsArray &uniformsArray [[ buffer(VertexBufferIndexUniforms) ]]) {
     
     Uniforms uniforms = uniformsArray.uniforms[amp_id];
     float4x4 projectionMatrix = uniforms.projectionMatrix;
@@ -53,7 +28,7 @@ vertex SkyCubeOut vertexSkycube(SkyCubeIn in [[stage_in]],
     // Use the sceneTransform as the model matrix as most scenes are z-up
     float4x4 modelViewProjectionMatrix = projectionMatrix * viewMatrix * uniforms.sceneTransform;
     
-    SkyCubeOut out;
+    VertexOut out;
     float4 position = (modelViewProjectionMatrix * in.position).xyww;
     out.position = position;
     out.textureCoordinates = in.position.xyz;
@@ -66,10 +41,10 @@ vertex SkyCubeOut vertexSkycube(SkyCubeIn in [[stage_in]],
 //   - in: the data passed from the vertex function.
 //   - cubeTexture: the cube texture.
 //   - colorSampler: The color sampler.
-fragment ColorOut fragmentSkycube(SkyCubeOut in [[stage_in]],
+fragment FragmentOut fragmentSkycube(VertexOut in [[stage_in]],
                                   texturecube<float> cubeTexture [[texture(0)]],
                                   sampler colorSampler [[sampler(0)]]) {
-    ColorOut out;
+    FragmentOut out;
     float4 color = cubeTexture.sample(colorSampler, in.textureCoordinates);
     out.color = color;
     out.index = in.index;

--- a/Sources/VimKitShaders/include/ShaderTypes.h
+++ b/Sources/VimKitShaders/include/ShaderTypes.h
@@ -5,8 +5,6 @@
 //  Created by Kevin McKee
 //
 
-//  Header containing types and enums shared between Metal shaders and Swift
-
 #ifndef ShaderTypes_h
 #define ShaderTypes_h
 
@@ -18,6 +16,10 @@ typedef metal::int32_t EnumBackingType;
 typedef NSInteger EnumBackingType;
 #endif
 #import <simd/simd.h>
+
+//***********************************************************************
+// SWIFT/METAL STRUCTURES THAT ARE SHARED BETWEEN METAL SHADERS AND SWIFT
+//***********************************************************************
 
 // Per Frame Uniforms
 typedef struct {
@@ -77,4 +79,55 @@ typedef NS_ENUM(EnumBackingType, VertexAttribute) {
     VertexAttributeUv = 2
 };
 
+//***********************************************************************
+// METAL ONLY STRUCTURES THAT CAN BE SHARED ACROSS METAL SHADERS
+//***********************************************************************
+
+#ifdef __METAL_VERSION__
+
+#include <metal_stdlib>
+using namespace metal;
+
+// Describes the incoming vertex data that is sent to a shader vertex function.
+typedef struct {
+    float4 position [[attribute(VertexAttributePosition)]];
+    float3 normal [[attribute(VertexAttributeNormal)]];
+    float2 uv [[attribute(VertexAttributeUv)]];
+} VertexIn;
+
+// The struct that is passed from the vertex function to the fragment function
+typedef struct {
+    // The position of the vertex
+    float4 position [[position]];
+    // The normal from the perspective of the camera
+    float3 cameraNormal;
+    // The directional vector from the perspective of the camera
+    float3 cameraDirection;
+    // The direction of the light from the position of the camera
+    float3 cameraLightDirection;
+    // The distance from camera to the vertex
+    float cameraDistance;
+    // The material color
+    float4 color;
+    // The material glossiness
+    float glossiness;
+    // The material smoothness
+    float smoothness;
+    // The texture coordinates
+    float3 textureCoordinates;
+    // The instance index (-1 indicates a non-selectable or invalid instance)
+    int32_t index;
+} VertexOut;
+
+// The struct that is returned from the fragment function
+typedef struct {
+    // The colorAttachments[0] that holds the color information
+    float4 color [[color(0)]];
+    // The colorAttachments[1] that holds the instance index (-1 indicates a non-selectable or invalid instance)
+    int32_t index [[color(1)]];
+} FragmentOut;
+
+#endif
+
 #endif /* ShaderTypes_h */
+


### PR DESCRIPTION
# Description

Sharing metal data structures that can be used across metal `vertex` and `fragment` shader functions:

- `VertexIn`
- `VertexOut`
- `FragmentOut`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
