### PR TITLE
SwiftData Import Performance

### DIFF
--- a/Sources/VimKit/Database+Importer.swift
+++ b/Sources/VimKit/Database+Importer.swift
@@ -61,11 +61,11 @@ extension Database {
         /// Starts the import process.
         /// - Parameter limit: the max limit of models per entity to import
         func `import`(_ limit: Int = .max) {
-            
+
             defer {
                 try? modelExecutor.modelContext.save()
             }
-            
+
             let start = Date.now
 
             // Warm the cache for the models. TODO: This could be reworked ...

--- a/Sources/VimKit/Database+Importer.swift
+++ b/Sources/VimKit/Database+Importer.swift
@@ -42,7 +42,7 @@ extension Database {
         @MainActor @Published
         var progress = Progress(totalUnitCount: Int64(Database.models.count))
 
-        let batchSize = 1000
+        let batchSize = 1000 * 10
         let database: Database
         let modelContainer: ModelContainer
         let modelExecutor: ModelExecutor
@@ -61,6 +61,11 @@ extension Database {
         /// Starts the import process.
         /// - Parameter limit: the max limit of models per entity to import
         func `import`(_ limit: Int = .max) {
+            
+            defer {
+                try? modelExecutor.modelContext.save()
+            }
+            
             let start = Date.now
 
             // Warm the cache for the models. TODO: This could be reworked ...
@@ -87,12 +92,8 @@ extension Database {
                     debugPrint("􁃎 [\(modelName)] - skipping import")
                     continue
                 }
+
                 importModel(modelType, limit)
-                do {
-                    try modelContext.save()
-                } catch let error {
-                    debugPrint("💀", error)
-                }
             }
             let timeInterval = abs(start.timeIntervalSinceNow)
             debugPrint("􁗫 Database imported in [\(timeInterval.stringFromTimeInterval())]")
@@ -178,11 +179,6 @@ extension Database {
         private func updateMeta(_ modelName: String, state: ModelMetadata.State) {
             let meta = meta(modelName)
             meta.state = state
-            do {
-                try modelContext.save()
-            } catch let error {
-                debugPrint("💀", error)
-            }
         }
 
         /// Upserts a model of the specified type at the specified index with the row data.

--- a/Sources/VimKit/Database+Models.swift
+++ b/Sources/VimKit/Database+Models.swift
@@ -211,9 +211,9 @@ extension Database {
 
         public func update(from data: [String: AnyHashable], cache: ImportCache) {
             typeName = data["AssemblyTypeName"] as? String ?? .empty
-            positionX = data["Position.X"] as? Float ?? .zero
-            positionY = data["Position.Y"] as? Float ?? .zero
-            positionZ = data["Position.Z"] as? Float ?? .zero
+            positionX = data["PositionX"] as? Float ?? .zero
+            positionY = data["PositionY"] as? Float ?? .zero
+            positionZ = data["PositionZ"] as? Float ?? .zero
             if let idx = data["Element"] as? Int64, idx != .empty {
                 element = cache.findOrCreate(idx)
             }
@@ -613,9 +613,9 @@ extension Database {
 
         public func update(from data: [String: AnyHashable], cache: ImportCache) {
             type = data["GroupType"] as? String ?? .empty
-            positionX = data["Position.X"] as? Float ?? .zero
-            positionY = data["Position.Y"] as? Float ?? .zero
-            positionZ = data["Position.Z"] as? Float ?? .zero
+            positionX = data["PositionX"] as? Float ?? .zero
+            positionY = data["PositionY"] as? Float ?? .zero
+            positionZ = data["PositionZ"] as? Float ?? .zero
             if let idx = data["Element"] as? Int64, idx != .empty {
                 element = cache.findOrCreate(idx)
             }
@@ -926,21 +926,21 @@ extension Database {
         }
 
         public func update(from data: [String: AnyHashable], cache: ImportCache) {
-            originX = (data["Origin.X"] as? Double ?? .zero).singlePrecision
-            originY = (data["Origin.Y"] as? Double ?? .zero).singlePrecision
-            originZ = (data["Origin.Z"] as? Double ?? .zero).singlePrecision
-            directionX = (data["ViewDirection.X"] as? Double ?? .zero).singlePrecision
-            directionY = (data["ViewDirection.Y"] as? Double ?? .zero).singlePrecision
-            directionZ = (data["ViewDirection.Z"] as? Double ?? .zero).singlePrecision
-            positionX = (data["ViewPosition.X"] as? Double ?? .zero).singlePrecision
-            positionY = (data["ViewPosition.Y"] as? Double ?? .zero).singlePrecision
-            positionZ = (data["ViewPosition.Z"] as? Double ?? .zero).singlePrecision
-            upX = (data["Up.X"] as? Double ?? .zero).singlePrecision
-            upY = (data["Up.Y"] as? Double ?? .zero).singlePrecision
-            upZ = (data["Up.Z"] as? Double ?? .zero).singlePrecision
-            rightX = (data["Right.X"] as? Double ?? .zero).singlePrecision
-            rightY = (data["Right.Y"] as? Double ?? .zero).singlePrecision
-            rightZ = (data["Right.Z"] as? Double ?? .zero).singlePrecision
+            originX = (data["OriginX"] as? Double ?? .zero).singlePrecision
+            originY = (data["OriginY"] as? Double ?? .zero).singlePrecision
+            originZ = (data["OriginZ"] as? Double ?? .zero).singlePrecision
+            directionX = (data["ViewDirectionX"] as? Double ?? .zero).singlePrecision
+            directionY = (data["ViewDirectionY"] as? Double ?? .zero).singlePrecision
+            directionZ = (data["ViewDirectionZ"] as? Double ?? .zero).singlePrecision
+            positionX = (data["ViewPositionX"] as? Double ?? .zero).singlePrecision
+            positionY = (data["ViewPositionY"] as? Double ?? .zero).singlePrecision
+            positionZ = (data["ViewPositionZ"] as? Double ?? .zero).singlePrecision
+            upX = (data["UpX"] as? Double ?? .zero).singlePrecision
+            upY = (data["UpY"] as? Double ?? .zero).singlePrecision
+            upZ = (data["UpZ"] as? Double ?? .zero).singlePrecision
+            rightX = (data["RightX"] as? Double ?? .zero).singlePrecision
+            rightY = (data["RightY"] as? Double ?? .zero).singlePrecision
+            rightZ = (data["RightZ"] as? Double ?? .zero).singlePrecision
             scale = (data["Scale"] as? Double ?? .zero).singlePrecision
 
             if let idx = data["Camera"] as? Int64, idx != .empty {

--- a/Sources/VimKit/Database.swift
+++ b/Sources/VimKit/Database.swift
@@ -16,20 +16,132 @@ private let sqliteExtension = ".sqlite"
 @dynamicMemberLookup
 public class Database: ObservableObject {
 
-    @dynamicMemberLookup
     public class Table {
+
+        class Rows {
+
+            /// Holds a hash of colums.
+            let columns: [String: Column]
+
+            /// Convenience var for accessing the table colum names sorted alphabetically.
+            lazy var columnNames: [String] = {
+                columns.keys.sorted { $0 < $1 }
+            }()
+
+            /// Returns the row count.
+            var count: Int {
+                columns.first?.value.rows.count ?? 0
+            }
+
+            /// Initializer.
+            /// - Parameter columns: the colums hash
+            init(columns: [String: Column]) {
+                self.columns = columns
+                validate()
+            }
+
+            /// Subscript that returns a single row hash of the column name and it's type erased at the specified index.
+            subscript(index: Int) -> [String: AnyHashable] {
+                var row = [String: AnyHashable]()
+                for (key, column) in columns {
+                    row[key] = column.rows[index]
+                }
+                return row
+            }
+
+            /// Validates the table to ensure all colums have the same row count.
+            private func validate() {
+                // Validate the rows in all of the columns have the same count
+                var counts = [Int]()
+
+                guard columns.isNotEmpty else { return }
+                for (_, column) in columns {
+                    counts.append(column.rows.count)
+                }
+                let set = Set(counts)
+                assert(set.count == 1, "The number of rows in the columns aren't equal")
+            }
+
+        }
 
         /// Table Column
         public class Column: Identifiable {
 
+            /// Column Data Wrapper that allows us to subscript the underlying storage
+            protocol DataWrapper {
+
+                /// Returns the number of rows in the column.
+                var count: Int { get }
+
+                /// Subscript that returns the storage data at the specified index as type erased data.
+                subscript(index: Int) -> AnyHashable { get }
+            }
+
+
+            /// A Column Data wrapper that holds storage of the specified type.
+            class TypedDataWrapper<T: Hashable>: DataWrapper {
+
+                /// The colum data.
+                let data: Data
+
+                /// The total count of rows.
+                var count: Int {
+                    let storage: UnsafeBufferPointer<T> = data.toUnsafeBufferPointer()
+                    return storage.count
+                }
+
+                /// Initializer.
+                /// - Parameter data: the underlying storage data
+                init(data: Data) {
+                    self.data = data
+                }
+
+                /// Subscript that returns the storage data at the specified index as type erased data.
+                subscript(index: Int) -> AnyHashable {
+                    let storage: UnsafeBufferPointer<T> = data.toUnsafeBufferPointer()
+                    return storage[index]
+                }
+            }
+
+            /// A Column Data wrapper that holds storage of indices into the indexed string provider.
+            class StringDataWrapper: TypedDataWrapper<Int32> {
+
+                /// The indexed string provider.
+                let stringDataProvider: IndexedStringDataProvider
+
+                /// Initializer
+                /// - Parameters:
+                ///   - data: the storage data
+                ///   - stringDataProvider: the indexed string data provider.
+                init(data: Data, stringDataProvider: IndexedStringDataProvider) {
+                    self.stringDataProvider = stringDataProvider
+                    super.init(data: data)
+                }
+
+                /// Subscript that returns the storage data at the specified index as type erased data.
+                override subscript(index: Int) -> AnyHashable {
+                    let storage: UnsafeBufferPointer<Int32> = data.toUnsafeBufferPointer()
+                    let i = Int(storage[index])
+                    return stringDataProvider.string(at: i)
+                }
+            }
+
+            /// The column data type
             enum DataType: String {
-                case byte // 8 bit value, typically used for booleans
-                case index // 32-bit signed integer used to reference a relation to a row in another table
-                case int // 32-bit signed integer
-                case string // The strings column is a Int32 which is used as the index into the strings buffer
-                case double // 64-bit double-precision floating point values
-                case long // 64-bit signed integer
-                case float // 32-bit single-precision floating point values
+                /// 8 bit value, typically used for booleans
+                case byte
+                /// 32-bit signed integer used to reference a relation to a row in another table
+                case index
+                /// 32-bit signed integer
+                case int
+                /// The strings column is a Int32 which is used as the index into the strings buffer
+                case string
+                /// 64-bit double-precision floating point values
+                case double
+                /// 64-bit signed integer
+                case long
+                /// 32-bit single-precision floating point values
+                case float
             }
 
             /// Identifiable id
@@ -45,70 +157,42 @@ public class Database: ObservableObject {
             let dataType: DataType
             /// The data buffer that contains the coiumn data
             private let buffer: BFast.Buffer
-            /// The string data provider used to peform string lookups
-            private weak var stringDataProvider: IndexedStringDataProvider?
+            /// The column data.
+            let rows: DataWrapper
 
             /// Initializes the column.
+            /// See: See: https://github.com/vimaec/vim#entities-buffer
             ///
             /// - Parameters:
             ///   - buffer: The data buffer that holds the column data
             ///   - stringDataProvider: The string data provider
             init?(_ buffer: BFast.Buffer, _ stringDataProvider: IndexedStringDataProvider) {
                 self.buffer = buffer
-                self.stringDataProvider = stringDataProvider
                 let descriptor = buffer.name.components(separatedBy: ":")
                 guard let dataType = DataType(rawValue: descriptor[0]) else { return nil }
                 self.dataType = dataType
                 self.name = descriptor.last!
                 self.index = dataType == .index ? descriptor[1].replacingOccurrences(of: ".", with: "") : nil
-            }
-
-            /// Returns the raw data as an array
-            /// TODO: This can be made more memory effecient
-            lazy var rows: [AnyHashable] = {
                 switch dataType {
                 case .byte:
-                    let results: [UInt8] = buffer.data.unsafeTypeArray()
-                    return results
+                    self.rows = TypedDataWrapper<UInt8>(data: buffer.data)
                 case .index, .int:
-                    let results: [Int32] = buffer.data.unsafeTypeArray()
-                    return results
+                    self.rows = TypedDataWrapper<Int32>(data: buffer.data)
                 case .string:
-                    let results: [Int32] = buffer.data.unsafeTypeArray()
-                    let strings = results.map { stringDataProvider?.string(at: Int($0)) ?? .empty }
-                    return strings
+                    self.rows = StringDataWrapper(data: buffer.data, stringDataProvider: stringDataProvider)
                 case .double:
-                    let results: [Double] = buffer.data.unsafeTypeArray()
-                    return results
+                    self.rows = TypedDataWrapper<Double>(data: buffer.data)
                 case .long:
-                    let results: [Int64] = buffer.data.unsafeTypeArray()
-                    return results
+                    self.rows = TypedDataWrapper<Int64>(data: buffer.data)
                 case .float:
-                    let results: [Float] = buffer.data.unsafeTypeArray()
-                    return results
-                }
-            }()
-
-            /// Returns the number of rows inside the column.
-            /// See: https://github.com/vimaec/vim#entities-buffer
-            var count: Int {
-                switch self.dataType {
-                case .byte:
-                    return Int(self.buffer.data.count / MemoryLayout<UInt8>.size)
-                case .index, .int, .string:
-                    return Int(self.buffer.data.count / MemoryLayout<Int32>.size)
-                case .double:
-                    return Int(self.buffer.data.count / MemoryLayout<Double>.size)
-                case .long:
-                    return Int(self.buffer.data.count / MemoryLayout<Int64>.size)
-                case .float:
-                    return Int(self.buffer.data.count / MemoryLayout<Float>.size)
+                    self.rows = TypedDataWrapper<Float>(data: buffer.data)
                 }
             }
         }
 
-        /// The columns inside this table
-        var columns = [String: Column]()
+        /// The table rows
+        var rows: Rows
+
         /// The data buffer that contains the table data
         private let buffer: BFast.Buffer
 
@@ -120,25 +204,15 @@ public class Database: ObservableObject {
         init?(_ buffer: BFast.Buffer, _ stringDataProvider: IndexedStringDataProvider) {
             self.buffer = buffer
             guard let bfast = BFast(buffer: buffer) else { return nil }
+            var columns = [String: Column]()
             // The columns of the table are encoded as BFast buffers
             for (_, buffer) in bfast.buffers.enumerated() {
                 guard let column = Column(buffer, stringDataProvider) else { continue }
-                columns[column.name.replacingOccurrences(of: ".", with: "")] = column
+                let name = column.name.replacingOccurrences(of: ".", with: "")
+                columns[name] = column
             }
-            // Validate the table
-            validate()
-        }
-
-        /// Validates the table to ensure all colums have the same row count.
-        private func validate() {
-            // Validate the rows in all of the columns have the same count
-            var counts = [Int]()
-            guard columns.isNotEmpty else { return }
-            for (_, column) in columns {
-                counts.append(column.count)
-            }
-            let set = Set(counts)
-            assert(set.count == 1, "The number of rows in the columns aren't equal")
+            guard columns.isNotEmpty else { return nil }
+            self.rows = Rows(columns: columns)
         }
 
         /// The name of the table
@@ -146,46 +220,23 @@ public class Database: ObservableObject {
             buffer.name
         }
 
+        /// Convenience var for accessing the table colum names sorted alphabetically.
+        public var columns: [String] {
+            rows.columnNames
+        }
+
         /// Returns the number of rows this table has
         public var count: Int {
-            columns.values.first?.count ?? 0
-        }
-
-        /// Dynamic subscipt to use `.dot syntax` for referencing a table column
-        subscript(dynamicMember member: String) -> Column? {
-            columns[member]
-        }
-
-        /// Convenience var for accessing the table colum names sorted alphabetically.
-        public lazy var columnNames: [String] = {
-            let names = Array(columns.keys)
-            return names.sorted { $0 < $1 }
-        }()
-
-        /// Fetches the column data inside the table
-        public func select(_ columnNames: [String]? = nil) -> [Column] {
-            var results = [Column]()
-            // Filter columns
-            if let columnNames = columnNames {
-                for name in columnNames {
-                    if let column = columns[name] {
-                        results.append(column)
-                    }
-                }
-            } else {
-                // Include all all columns
-                for (_, column) in columns {
-                    results.append(column)
-                }
-            }
-            return results
+            rows.count
         }
     }
 
     /// The tables contained inside this buffer
     var tables = [String: Table]()
+
     /// The encapsulating data buffer
     let bfast: BFast
+
     /// Cancellable tasks.
     var tasks = [Task<(), Never>]()
 
@@ -196,13 +247,6 @@ public class Database: ObservableObject {
 
     /// The SwiftData model container
     public var modelContainer: ModelContainer
-
-    /// The private pass through result set publisher.
-    private var resultSetPublisher = PassthroughSubject<ResultSet, Never>()
-
-    /// Provides a pass through subject used to broadcast result sets.
-    /// The subject will automatically drop events if there are no subscribers, or its current demand is zero.
-    public lazy var results = resultSetPublisher.eraseToAnyPublisher()
 
     /// Initializes the database with the specified BFast container.
     ///
@@ -237,8 +281,7 @@ public class Database: ObservableObject {
 
     /// Convenience var for accessing the table names sorted alphabetically.
     public lazy var tableNames: [String] = {
-        let names = Array(tables.keys)
-        return names.sorted { $0 < $1 }
+        tables.keys.sorted { $0 < $1 }
     }()
 
     /// Dynamic subscipt to use `.dot syntax` for referencing tables
@@ -248,117 +291,5 @@ public class Database: ObservableObject {
     /// `let table = entites.VimGeometry`.
     subscript(dynamicMember member: String) -> Table? {
         tables[member]
-    }
-}
-
-// MARK: Database Queries (Raw Data)
-
-extension Database {
-
-    /// Fetches the raw table data.
-    /// - Parameters:
-    ///   - tableName: The name of the table to fetch data from
-    public func select(_ tableName: String? = nil) {
-
-        guard let tableName, let table = tables[tableName] else { return }
-
-        Task {
-            let resultSet = ResultSet(table)
-            DispatchQueue.main.async {
-                self.resultSetPublisher.send(resultSet)
-            }
-        }
-    }
-}
-
-@dynamicMemberLookup
-public struct ResultSet: RandomAccessCollection, Sequence {
-
-    public typealias Element = [String: AnyHashable]
-
-    public typealias Index = Int
-
-    public typealias Indices = CountableRange<Int>
-
-    public var startIndex: Int {
-        rows.startIndex
-    }
-
-    public var endIndex: Int {
-        rows.endIndex
-    }
-
-    public var count: Int {
-        rows.count
-    }
-
-    public subscript(position: Int) -> [String: AnyHashable] {
-        rows[position]
-    }
-
-    public subscript(dynamicMember member: String) -> String? {
-        member
-    }
-
-    public let tableName: String
-    public let columnNames: [String]
-    fileprivate let columns: [Database.Table.Column]
-    fileprivate var rows = [[String: AnyHashable]]()
-
-    init(_ table: Database.Table) {
-        self.tableName = table.name
-        self.columns = Array(table.columns.values)
-        self.columnNames = columns.map { $0.name }.sorted { $0 < $1 }
-
-        let count = columns.first?.count ?? 0
-        for i in 0..<count {
-            var row = [String: AnyHashable]()
-            for column in columns {
-                row[column.name] = column.rows[i]
-            }
-            rows.append(row)
-        }
-    }
-
-    init(_ tableName: String, _ colums: [Database.Table.Column]) {
-        self.tableName = tableName
-        self.columns = colums
-        self.columnNames = columns.map { $0.name }.sorted { $0 < $1 }
-
-        let count = columns.first?.count ?? 0
-        for i in 0..<count {
-            var row = [String: AnyHashable]()
-            for column in columns {
-                row[column.name] = column.rows[i]
-            }
-            rows.append(row)
-        }
-    }
-
-    public static func == (lhs: ResultSet, rhs: ResultSet) -> Bool {
-        lhs.tableName == rhs.tableName && lhs.count == rhs.count
-    }
-}
-
-struct ResultSetIterator: IteratorProtocol {
-
-    private let resultSet: ResultSet
-    private let count: Int
-    private var index: Int
-
-    init(_ resultSet: ResultSet) {
-        self.resultSet = resultSet
-        self.index = 0
-        self.count = resultSet.columns.first?.count ?? 0
-    }
-
-    mutating func next() -> [String: AnyHashable]? {
-        guard index < count else { return nil }
-        var row = [String: AnyHashable]()
-        for column in resultSet.columns {
-            row[column.name] = column.rows[index]
-        }
-        index += 1
-        return row
     }
 }

--- a/Sources/VimKit/Extensions/Data+Extensions.swift
+++ b/Sources/VimKit/Extensions/Data+Extensions.swift
@@ -57,7 +57,7 @@ extension Data {
     /// - Returns: a mutable buffer pointer of the specified type.
     func toUnsafeBufferPointer<T>() -> UnsafeBufferPointer<T> {
         withUnsafeBytes { (pointer) -> UnsafeBufferPointer<T> in
-            pointer.bindMemory(to: T.self)
+            pointer.assumingMemoryBound(to: T.self)
         }
     }
 

--- a/Sources/VimKit/Extensions/Data+Extensions.swift
+++ b/Sources/VimKit/Extensions/Data+Extensions.swift
@@ -48,8 +48,16 @@ extension Data {
     func unsafeTypeArray<T>(_ count: Int? = nil) -> [T] {
         let count = count ?? Int(self.count / MemoryLayout<T>.size)
         return withUnsafeBytes { (pointer) -> [T] in
-            let buffer = UnsafeBufferPointer(start: pointer.baseAddress!.assumingMemoryBound(to: T.self), count: count)
+            let buffer = UnsafeBufferPointer(start: pointer.baseAddress?.assumingMemoryBound(to: T.self), count: count)
             return Array(buffer)
+        }
+    }
+
+    /// Builds an UnsafeMutableBufferPointer from the buffer contents of the specifed type.
+    /// - Returns: a mutable buffer pointer of the specified type.
+    func toUnsafeBufferPointer<T>() -> UnsafeBufferPointer<T> {
+        withUnsafeBytes { (pointer) -> UnsafeBufferPointer<T> in
+            pointer.bindMemory(to: T.self)
         }
     }
 


### PR DESCRIPTION
# Description

Seeing > `~21%` import time improvements. Would like to revisit this in the future though as it still seems rather slow.

**Residence.vim**
- Before: `Database imported in [00:00:39.513]`
- After: `Database imported in [00:00:31.997]`

**Dwelling.vim**
- Before: `Database imported in [00:00:38.113]`
- After:  `Database imported in [00:00:30.442]`

Fixes #21 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
