### PR TITLE
Shader Port

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The VimKit package is broken down into 3 seperate modules ([VimKit](#vimkit-1), 
 
 [VIM](https://github.com/vimaec/vim) files are composed of [BFAST](https://github.com/vimaec/bfast) containers that provide the necessary [geometry](https://github.com/vimaec/vim#geometry-buffer), [assets](https://github.com/vimaec/vim/#assets-buffer), [entities](https://github.com/vimaec/vim#entities-buffer), and [strings](https://github.com/vimaec/vim#strings-buffer) buffers used to render and interrogate all of the 3D instances contained in a file. 
 
-Although it is possible to render each [Instance](https://github.com/codefiesta/VimKit/blob/main/Sources/VimKit/Geometry%2BMesh.swift) individually, VimKit leverages instancing to render all Instance's that share the same Mesh in a single [draw](https://github.com/codefiesta/VimKit/blob/main/Sources/VimKit/Renderer/VimRenderer%2BDrawing.swift) call.
+Although it is possible to render each [Instance](https://github.com/codefiesta/VimKit/blob/main/Sources/VimKitShaders/include/ShaderTypes.h#L93) individually, VimKit leverages instancing to render all Instance's that share the same Mesh in a single [draw](https://github.com/codefiesta/VimKit/blob/main/Sources/VimKit/Renderer/VimRenderer%2BDrawing.swift) call.
 
-[Geometry.swift](https://github.com/codefiesta/VimKit/blob/main/Sources/VimKit/Geometry.swift) and [Geometry+Mesh.swift](https://github.com/codefiesta/VimKit/blob/main/Sources/VimKit/Geometry%2BMesh.swift) are the best sources to understand the details of how the geometry, positions, indices and data structures used for rendering are organized.
+[Geometry.swift](https://github.com/codefiesta/VimKit/blob/main/Sources/VimKit/Geometry.swift) and [ShaderTypes.h](https://github.com/codefiesta/VimKit/blob/main/Sources/VimKitShaders/include/ShaderTypes.h) are the best sources to understand the details of how the geometry, positions, indices and data structures used for rendering are organized.
 
 ## VimKit
 Provides the core library for reading and [rendering](https://github.com/codefiesta/VimKit/blob/main/Sources/VimKit/Renderer/VimRenderer.swift) VIM files on [macOS](https://developer.apple.com/macos/) and [iOS](https://developer.apple.com/ios/).

--- a/Sources/VimKit/Extensions/BoundedRange+Extensions.swift
+++ b/Sources/VimKit/Extensions/BoundedRange+Extensions.swift
@@ -2,7 +2,7 @@
 //  BoundedRange+Extensions.swift
 //  VimKit
 //
-//  Created by Kevin McKee on 10/7/24.
+//  Created by Kevin McKee
 //
 
 import Foundation

--- a/Sources/VimKit/Extensions/BoundedRange+Extensions.swift
+++ b/Sources/VimKit/Extensions/BoundedRange+Extensions.swift
@@ -1,0 +1,68 @@
+//
+//  BoundedRange+Extensions.swift
+//  VimKit
+//
+//  Created by Kevin McKee on 10/7/24.
+//
+
+import Foundation
+import VimKitShaders
+
+extension BoundedRange: @retroactive Equatable, @retroactive Hashable {
+
+    var count: Int {
+        Int(upperBound) - Int(lowerBound)
+    }
+
+    /// Convenience var to convert the bounded range into a Swift range.
+    var range: Range<Int> {
+        Int(lowerBound)..<Int(upperBound)
+    }
+
+    init(_ range: Range<Int>) {
+        self.init(lowerBound: UInt32(range.lowerBound), upperBound: UInt32(range.upperBound))
+    }
+
+    public static func == (lhs: BoundedRange, rhs: BoundedRange) -> Bool {
+        lhs.lowerBound == rhs.lowerBound && lhs.upperBound == rhs.upperBound
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(lowerBound)
+        hasher.combine(upperBound)
+    }
+}
+
+extension Array {
+
+    // Convenience subscript using a bounded range
+    subscript(boundedRange: BoundedRange) -> ArraySlice<Element> {
+        let range = Int(boundedRange.lowerBound)..<Int(boundedRange.upperBound)
+        return self[range]
+    }
+
+    // Convenience subscript using an UInt32 index
+    subscript(index: UInt32) -> Element {
+        self[Int(index)]
+    }
+
+    // Convenience subscript using an Int32 index
+    subscript(index: Int32) -> Element {
+        assert(index != .empty, "Attempt to subscript with an negative index")
+        return self[Int(index)]
+    }
+}
+
+extension UnsafeMutableBufferPointer {
+
+    // Convenience subscript using a bounded range
+    subscript(boundedRange: BoundedRange) -> Slice<UnsafeMutableBufferPointer<Element>> {
+        let range = Int(boundedRange.lowerBound)..<Int(boundedRange.upperBound)
+        return self[range]
+    }
+
+    // Convenience subscript using an Int32 index
+    subscript(index: Int32) -> Element {
+        self[Int(index)]
+    }
+}

--- a/Sources/VimKit/Extensions/Color+Extensions.swift
+++ b/Sources/VimKit/Extensions/Color+Extensions.swift
@@ -10,6 +10,12 @@ import SwiftUI
 
 extension Color {
 
+    /// Represents the default object selection color.
+    /// Note: This should go away in the future and should be able to initialized via a
+    /// `ColorResource` with `.init(.objectSection)`.
+    /// See: https://forums.swift.org/t/generate-images-and-colors-inside-a-swift-package/65674/9
+    public static let objectSelectionColor = Color("objectSelectionColor", bundle: .module)
+
     /// Provides a convenience var for accessing the color channels
     var channels: SIMD4<Float> {
         let resolved = resolve(in: .init())
@@ -26,6 +32,7 @@ extension Color {
 extension SIMD4 where Scalar == Float {
 
     /// Initialize rgba values from a color resource.
+    /// - Parameter resource: the color resource
     init(_ resource: ColorResource) {
         let color = Color(resource)
         let channels = color.channels

--- a/Sources/VimKit/Extensions/Color+Extensions.swift
+++ b/Sources/VimKit/Extensions/Color+Extensions.swift
@@ -10,12 +10,6 @@ import SwiftUI
 
 extension Color {
 
-    /// Represents the default object selection color
-    public static let objectSelectionColor = Color("objectSelectionColor", bundle: .module)
-
-    /// Represents the sky blue color
-    public static let skyBlue = Color("skyBlueColor", bundle: .module)
-
     /// Provides a convenience var for accessing the color channels
     var channels: SIMD4<Float> {
         let resolved = resolve(in: .init())
@@ -27,5 +21,14 @@ extension Color {
         let c = channels
         return MTLClearColor(red: Double(c.x), green: Double(c.y), blue: Double(c.z), alpha: Double(c.w))
     }
+}
 
+extension SIMD4 where Scalar == Float {
+
+    /// Initialize rgba values from a color resource.
+    init(_ resource: ColorResource) {
+        let color = Color(resource)
+        let channels = color.channels
+        self.init(channels.x, channels.y, channels.z, channels.w)
+    }
 }

--- a/Sources/VimKit/Extensions/MDLAxisAlignedBoundingBox+Extensions.swift
+++ b/Sources/VimKit/Extensions/MDLAxisAlignedBoundingBox+Extensions.swift
@@ -10,6 +10,9 @@ import Spatial
 
 extension MDLAxisAlignedBoundingBox {
 
+    /// A constant for a zero size bounding boz
+    static let zero: MDLAxisAlignedBoundingBox = .init(maxBounds: .zero, minBounds: .zero)
+
     /// Returns the center point of the box.
     var center: SIMD3<Float> {
         (maxBounds + minBounds) * .half
@@ -177,5 +180,26 @@ extension MDLAxisAlignedBoundingBox {
             if distance > .zero { return true }
         }
         return false
+    }
+}
+
+extension MDLAxisAlignedBoundingBox {
+
+    /// Convenience operator that performs equality checks.
+    /// - Parameters:
+    ///   - lhs: the left box to check
+    ///   - rhs: the right box to check
+    /// - Returns: true if the boxes are equal
+    public static func == (lhs: MDLAxisAlignedBoundingBox, rhs: MDLAxisAlignedBoundingBox) -> Bool {
+        lhs.minBounds == rhs.minBounds && lhs.maxBounds == rhs.maxBounds
+    }
+
+    /// Convenience operator that performs non-equality checks.
+    /// - Parameters:
+    ///   - lhs: the left box to check
+    ///   - rhs: the right box to check
+    /// - Returns: true if the boxes are not equal
+    public static func != (lhs: MDLAxisAlignedBoundingBox, rhs: MDLAxisAlignedBoundingBox) -> Bool {
+        lhs.minBounds != rhs.minBounds || lhs.maxBounds != rhs.maxBounds
     }
 }

--- a/Sources/VimKit/Geometry+Mesh.swift
+++ b/Sources/VimKit/Geometry+Mesh.swift
@@ -10,8 +10,8 @@ import VimKitShaders
 /// Inverts the relationship between an Instance and a Mesh that allows us to draw using instancing.
 class InstancedMesh {
 
-    /// The mesh that is shared across the instances.
-    let mesh: Mesh
+    /// The mesh index that is shared across the instances.
+    let mesh: Int32
     /// Flag indicating if the mesh is transparent or not
     let transparent: Bool
     /// The instance indexes.
@@ -21,11 +21,11 @@ class InstancedMesh {
 
     /// Initalizes the instanced mesh.
     /// - Parameters:
-    ///   - mesh: the mesh that should be instanced
+    ///   - mesh: the index of the mesh that should be instanced
     ///   - transparent: a flag indicating if the instance is transparent or not (used primarily for sorting).
     ///   - instances: the instance indexes
     ///   - baseInstance: the offset used by the GPU used to lookup the starting index into the instances buffer.
-    init(mesh: Mesh, transparent: Bool, instances: [UInt32], _ baseInstance: Int = 0) {
+    init(mesh: Int32, transparent: Bool, instances: [UInt32], _ baseInstance: Int = 0) {
         self.mesh = mesh
         self.transparent = transparent
         self.instances = instances

--- a/Sources/VimKit/Geometry+Mesh.swift
+++ b/Sources/VimKit/Geometry+Mesh.swift
@@ -35,21 +35,24 @@ class InstancedMesh {
 
 extension Instance {
 
-    var boundingBox: MDLAxisAlignedBoundingBox? {
-        set {
-            maxBounds = newValue != nil ? newValue!.maxBounds : .zero
-            minBounds = newValue != nil ? newValue!.minBounds : .zero
-        }
-        get {
-            guard maxBounds != .zero, minBounds != .zero else { return nil }
-            return .init(maxBounds: maxBounds, minBounds: minBounds)
-        }
+    /// Convenience var that returns the bounding box.
+    var boundingBox: MDLAxisAlignedBoundingBox {
+        .init(maxBounds: maxBounds, minBounds: minBounds)
     }
 
+    /// Convenience var that returns the longest edge
     var longestEdge: Float {
-        boundingBox?.longestEdge ?? .zero
+        boundingBox.longestEdge
     }
 
+    /// Initializer.
+    /// - Parameters:
+    ///   - index: the instance index
+    ///   - matrix: the 4x4 row-major matrix representing the node's world-space transform
+    ///   - flags: The first bit of each flag designates whether the instance should be initially hidden (1) or not (0) when rendered.
+    ///   - parent: the parent index (-1 indicates no parent)
+    ///   - mesh: the mesh index (-1 indicates this instance has no mesh)
+    ///   - transparent: Flag indicating if the instance is transparent or not.
     init(index: Int, matrix: float4x4, flags: Int16, parent: Int32, mesh: Int32, transparent: Bool) {
         self.init(index: UInt32(index),
                   colorIndex: .empty,
@@ -64,20 +67,17 @@ extension Instance {
     }
 }
 
-extension Mesh: @retroactive Equatable, @retroactive Hashable {
+extension Mesh {
 
+    /// Initializes the mesh with a Swift range.
+    /// A mesh is composed of 0 or more submeshes.
+    ///
+    /// Can be used to find it's containing submeshes.
+    /// For example: `let submeshes = geometry.submeshes[mesh.submeshes]`
+    /// - Parameter range: the range of submeshes contained in this mesh.
     init(_ range: Range<Int>) {
         self.init(submeshes: .init(range))
     }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(submeshes)
-    }
-
-    public static func == (lhs: Mesh, rhs: Mesh) -> Bool {
-        lhs.submeshes.lowerBound == rhs.submeshes.lowerBound && lhs.submeshes.upperBound == rhs.submeshes.upperBound
-    }
-
 }
 
 extension Submesh {
@@ -87,148 +87,14 @@ extension Submesh {
         Int(indices.lowerBound) * MemoryLayout<UInt32>.size
     }
 
+    /// Initializes the submesh.
+    ///
+    /// The indices can be used to lookup the values inside the index buffer.
+    /// For example: `let indices = geometry.indices[submesh.indices]`
+    /// - Parameters:
+    ///   - material: The submesh's material index (-1 denotes no material).
+    ///   - indices: The range of values in the index buffer.
     init(_ material: Int32, _ indices: Range<Int>) {
         self.init(material: material, indices: .init(indices))
     }
-
 }
-
-//
-//extension Geometry {
-//
-//    public class Instance: @unchecked Sendable {
-//
-//        /// The index of the instance
-//        public let index: Int
-//        /// 4x4 row-major matrix representing the node's world-space transform
-//        public let matrix: float4x4
-//        /// The first bit of each flag designates whether the instance should be initially hidden (1) or not (0) when rendered.
-//        public let flags: Int16
-//        /// Flag indicating if the instance is transparent or not.
-//        public var transparent: Bool = false
-//        /// A reference to the parent instance
-//        public weak var parent: Instance?
-//        /// The mesh information
-//        public var mesh: Mesh?
-//
-//        /// A computed axis aligned bounding box from all of the submesh vertices or nil if this instance contains no mesh.
-//        public var boundingBox: MDLAxisAlignedBoundingBox?
-//
-//        /// Returns the longest edge of this instance
-//        public var longestEdge: Float {
-//            boundingBox?.longestEdge ?? .zero
-//        }
-//
-//        /// Initializes the instance.
-//        /// 
-//        /// - Parameters:
-//        ///   - index: The instance index. Use this to find instances
-//        ///     within the geometry rather than the subscript as
-//        ///     the array of instances will most likely be sorted differently.
-//        ///   - matrix: The 4x4 row-major matrix representing the node's world-space transform
-//        ///   - flags: Holds the flags for the given instance.
-//        init(index: Int, matrix: float4x4, flags: Int16) {
-//            self.index = index
-//            self.matrix = matrix
-//            self.flags = flags
-//        }
-//    }
-//
-//    /// A mesh is composed of 0 or more submeshes.
-//    public struct Mesh: Equatable, Hashable {
-//
-//        /// The range of submeshes contained inside this mesh.
-//        ///
-//        /// Can be used to find it's containing submeshes.
-//        /// For example: `let submeshes = geometry.submeshes[mesh.submeshes]`
-//        public let submeshes: Range<Int>?
-//
-//        /// Initializes the mesh.
-//        ///
-//        /// - Parameters:
-//        ///   - submeshes: The range of submeshes contained inside this mesh
-//        init(submeshes: Range<Int>? = nil) {
-//            self.submeshes = submeshes
-//        }
-//    }
-//
-//    /// Inverts the relationship between an Instance and a Mesh that allows us to draw using instancing.
-//    class InstancedMesh {
-//
-//        /// The mesh that is shared across the instances.
-//        let mesh: Mesh
-//        /// Flag indicating if the mesh is transparent or not
-//        let transparent: Bool
-//        /// The instance indexes.
-//        let instances: [UInt32]
-//        /// Provides an offset into the instances buffer.
-//        var baseInstance: Int
-//
-//        /// Initalizes the instanced mesh.
-//        /// - Parameters:
-//        ///   - mesh: the mesh that should be instanced
-//        ///   - transparent: a flag indicating if the instance is transparent or not (used primarily for sorting).
-//        ///   - instances: the instance indexes
-//        ///   - baseInstance: the offset used by the GPU used to lookup the starting index into the instances buffer.
-//        init(mesh: Mesh, transparent: Bool, instances: [UInt32], _ baseInstance: Int = 0) {
-//            self.mesh = mesh
-//            self.transparent = transparent
-//            self.instances = instances
-//            self.baseInstance = baseInstance
-//        }
-//    }
-//
-//    public struct Submesh {
-//
-//        /// The range of values in the index buffer to define the geometry of its triangular faces in local space.
-//        ///
-//        /// For example: `let indices = geometry.indices[submesh.indices]`
-//        public var indices: Range<Int>
-//
-//        /// The submesh's byte offset into the index buffer.
-//        public var indexBufferOffset: Int {
-//            indices.lowerBound * MemoryLayout<UInt32>.size
-//        }
-//
-//        /// The mesh material.
-//        public var material: Material?
-//
-//        /// Initializes the submesh.
-//        ///
-//        /// - Parameters:
-//        ///   - indices: The range of values in the index buffer.
-//        ///   - material: The submesh's material.
-//        init(indices: Range<Int>, material: Material? = nil) {
-//            self.indices = indices
-//            self.material = material
-//        }
-//    }
-//
-//    /// A type that holds material information.
-//    public struct Material {
-//
-//        /// The material glossiness in the domain of [0.0...0.1]
-//        public var glossiness: Float = .zero
-//
-//        /// The material smoothness in the domain of [0.0...0.1]
-//        public var smoothness: Float = .zero
-//
-//        /// The material RGBA diffuse color with components in the domain of [0.0...0.1]
-//        public var rgba: SIMD4<Float> = .zero
-//    }
-//
-//    /// A type that holds geometric shape information.
-//    public struct Shape {
-//
-//        /// The shape RGBA color with components in the domain of [0.0...0.1]
-//        public var rgba: SIMD4<Float> = .zero
-//
-//        /// The width of the shape
-//        public var width: Float
-//
-//        /// References a slice of vertices in the shape vertex buffer.
-//        ///
-//        /// For example: `let vertices = geometry.shapeVertexBuffer[shape.indices]`
-//        public var indices: Range<Int>
-//    }
-//}

--- a/Sources/VimKit/Geometry+Mesh.swift
+++ b/Sources/VimKit/Geometry+Mesh.swift
@@ -1,147 +1,234 @@
-//
-//  Geometry+Mesh.swift
-//  VimKit
-//
-//  Created by Kevin McKee
-//
+////
+////  Geometry+Mesh.swift
+////  VimKit
+////
+////  Created by Kevin McKee
+////
 import MetalKit
-import simd
+import VimKitShaders
 
-extension Geometry {
+/// Inverts the relationship between an Instance and a Mesh that allows us to draw using instancing.
+class InstancedMesh {
 
-    public class Instance: @unchecked Sendable {
+    /// The mesh that is shared across the instances.
+    let mesh: Mesh
+    /// Flag indicating if the mesh is transparent or not
+    let transparent: Bool
+    /// The instance indexes.
+    let instances: [UInt32]
+    /// Provides an offset into the instances buffer.
+    var baseInstance: Int
 
-        /// The index of the instance
-        public let index: Int
-        /// 4x4 row-major matrix representing the node's world-space transform
-        public let matrix: float4x4
-        /// The first bit of each flag designates whether the instance should be initially hidden (1) or not (0) when rendered.
-        public let flags: Int16
-        /// Flag indicating if the instance is transparent or not.
-        public var transparent: Bool = false
-        /// A reference to the parent instance
-        public weak var parent: Instance?
-        /// The mesh information
-        public var mesh: Mesh?
-
-        /// A computed axis aligned bounding box from all of the submesh vertices or nil if this instance contains no mesh.
-        public var boundingBox: MDLAxisAlignedBoundingBox?
-
-        /// Returns the longest edge of this instance
-        public var longestEdge: Float {
-            boundingBox?.longestEdge ?? .zero
-        }
-
-        /// Initializes the instance.
-        /// 
-        /// - Parameters:
-        ///   - index: The instance index. Use this to find instances
-        ///     within the geometry rather than the subscript as
-        ///     the array of instances will most likely be sorted differently.
-        ///   - matrix: The 4x4 row-major matrix representing the node's world-space transform
-        ///   - flags: Holds the flags for the given instance.
-        init(index: Int, matrix: float4x4, flags: Int16) {
-            self.index = index
-            self.matrix = matrix
-            self.flags = flags
-        }
-    }
-
-    /// A mesh is composed of 0 or more submeshes.
-    public struct Mesh: Equatable, Hashable {
-
-        /// The range of submeshes contained inside this mesh.
-        ///
-        /// Can be used to find it's containing submeshes.
-        /// For example: `let submeshes = geometry.submeshes[mesh.submeshes]`
-        public let submeshes: Range<Int>?
-
-        /// Initializes the mesh.
-        ///
-        /// - Parameters:
-        ///   - submeshes: The range of submeshes contained inside this mesh
-        init(submeshes: Range<Int>? = nil) {
-            self.submeshes = submeshes
-        }
-    }
-
-    /// Inverts the relationship between an Instance and a Mesh that allows us to draw using instancing.
-    class InstancedMesh {
-
-        /// The mesh that is shared across the instances.
-        let mesh: Mesh
-        /// Flag indicating if the mesh is transparent or not
-        let transparent: Bool
-        /// The instance indexes.
-        let instances: [UInt32]
-        /// Provides an offset into the instances buffer.
-        var baseInstance: Int
-
-        /// Initalizes the instanced mesh.
-        /// - Parameters:
-        ///   - mesh: the mesh that should be instanced
-        ///   - transparent: a flag indicating if the instance is transparent or not (used primarily for sorting).
-        ///   - instances: the instance indexes
-        ///   - baseInstance: the offset used by the GPU used to lookup the starting index into the instances buffer.
-        init(mesh: Mesh, transparent: Bool, instances: [UInt32], _ baseInstance: Int = 0) {
-            self.mesh = mesh
-            self.transparent = transparent
-            self.instances = instances
-            self.baseInstance = baseInstance
-        }
-    }
-
-    public struct Submesh {
-
-        /// The range of values in the index buffer to define the geometry of its triangular faces in local space.
-        ///
-        /// For example: `let indices = geometry.indices[submesh.indices]`
-        public var indices: Range<Int>
-
-        /// The submesh's byte offset into the index buffer.
-        public var indexBufferOffset: Int {
-            indices.lowerBound * MemoryLayout<UInt32>.size
-        }
-
-        /// The mesh material.
-        public var material: Material?
-
-        /// Initializes the submesh.
-        ///
-        /// - Parameters:
-        ///   - indices: The range of values in the index buffer.
-        ///   - material: The submesh's material.
-        init(indices: Range<Int>, material: Material? = nil) {
-            self.indices = indices
-            self.material = material
-        }
-    }
-
-    /// A type that holds material information.
-    public struct Material {
-
-        /// The material glossiness in the domain of [0.0...0.1]
-        public var glossiness: Float = .zero
-
-        /// The material smoothness in the domain of [0.0...0.1]
-        public var smoothness: Float = .zero
-
-        /// The material RGBA diffuse color with components in the domain of [0.0...0.1]
-        public var rgba: SIMD4<Float> = .zero
-    }
-
-    /// A type that holds geometric shape information.
-    public struct Shape {
-
-        /// The shape RGBA color with components in the domain of [0.0...0.1]
-        public var rgba: SIMD4<Float> = .zero
-
-        /// The width of the shape
-        public var width: Float
-
-        /// References a slice of vertices in the shape vertex buffer.
-        ///
-        /// For example: `let vertices = geometry.shapeVertexBuffer[shape.indices]`
-        public var indices: Range<Int>
+    /// Initalizes the instanced mesh.
+    /// - Parameters:
+    ///   - mesh: the mesh that should be instanced
+    ///   - transparent: a flag indicating if the instance is transparent or not (used primarily for sorting).
+    ///   - instances: the instance indexes
+    ///   - baseInstance: the offset used by the GPU used to lookup the starting index into the instances buffer.
+    init(mesh: Mesh, transparent: Bool, instances: [UInt32], _ baseInstance: Int = 0) {
+        self.mesh = mesh
+        self.transparent = transparent
+        self.instances = instances
+        self.baseInstance = baseInstance
     }
 }
+
+extension Instance {
+
+    var boundingBox: MDLAxisAlignedBoundingBox? {
+        set {
+            maxBounds = newValue != nil ? newValue!.maxBounds : .zero
+            minBounds = newValue != nil ? newValue!.minBounds : .zero
+        }
+        get {
+            guard maxBounds != .zero, minBounds != .zero else { return nil }
+            return .init(maxBounds: maxBounds, minBounds: minBounds)
+        }
+    }
+
+    var longestEdge: Float {
+        boundingBox?.longestEdge ?? .zero
+    }
+
+    init(index: Int, matrix: float4x4, flags: Int16, parent: Int32, mesh: Int32, transparent: Bool) {
+        self.init(index: UInt32(index),
+                  colorIndex: .empty,
+                  matrix: matrix,
+                  state: flags != .zero ? .hidden : .default,
+                  minBounds: .zero,
+                  maxBounds: .zero,
+                  parent: parent,
+                  mesh: mesh,
+                  transparent: transparent
+        )
+    }
+}
+
+extension Mesh: @retroactive Equatable, @retroactive Hashable {
+
+    init(_ range: Range<Int>) {
+        self.init(submeshes: .init(range))
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(submeshes)
+    }
+
+    public static func == (lhs: Mesh, rhs: Mesh) -> Bool {
+        lhs.submeshes.lowerBound == rhs.submeshes.lowerBound && lhs.submeshes.upperBound == rhs.submeshes.upperBound
+    }
+
+}
+
+extension Submesh {
+
+    /// The submesh's byte offset into the index buffer.
+    public var indexBufferOffset: Int {
+        Int(indices.lowerBound) * MemoryLayout<UInt32>.size
+    }
+
+    init(_ material: Int32, _ indices: Range<Int>) {
+        self.init(material: material, indices: .init(indices))
+    }
+
+}
+
+//
+//extension Geometry {
+//
+//    public class Instance: @unchecked Sendable {
+//
+//        /// The index of the instance
+//        public let index: Int
+//        /// 4x4 row-major matrix representing the node's world-space transform
+//        public let matrix: float4x4
+//        /// The first bit of each flag designates whether the instance should be initially hidden (1) or not (0) when rendered.
+//        public let flags: Int16
+//        /// Flag indicating if the instance is transparent or not.
+//        public var transparent: Bool = false
+//        /// A reference to the parent instance
+//        public weak var parent: Instance?
+//        /// The mesh information
+//        public var mesh: Mesh?
+//
+//        /// A computed axis aligned bounding box from all of the submesh vertices or nil if this instance contains no mesh.
+//        public var boundingBox: MDLAxisAlignedBoundingBox?
+//
+//        /// Returns the longest edge of this instance
+//        public var longestEdge: Float {
+//            boundingBox?.longestEdge ?? .zero
+//        }
+//
+//        /// Initializes the instance.
+//        /// 
+//        /// - Parameters:
+//        ///   - index: The instance index. Use this to find instances
+//        ///     within the geometry rather than the subscript as
+//        ///     the array of instances will most likely be sorted differently.
+//        ///   - matrix: The 4x4 row-major matrix representing the node's world-space transform
+//        ///   - flags: Holds the flags for the given instance.
+//        init(index: Int, matrix: float4x4, flags: Int16) {
+//            self.index = index
+//            self.matrix = matrix
+//            self.flags = flags
+//        }
+//    }
+//
+//    /// A mesh is composed of 0 or more submeshes.
+//    public struct Mesh: Equatable, Hashable {
+//
+//        /// The range of submeshes contained inside this mesh.
+//        ///
+//        /// Can be used to find it's containing submeshes.
+//        /// For example: `let submeshes = geometry.submeshes[mesh.submeshes]`
+//        public let submeshes: Range<Int>?
+//
+//        /// Initializes the mesh.
+//        ///
+//        /// - Parameters:
+//        ///   - submeshes: The range of submeshes contained inside this mesh
+//        init(submeshes: Range<Int>? = nil) {
+//            self.submeshes = submeshes
+//        }
+//    }
+//
+//    /// Inverts the relationship between an Instance and a Mesh that allows us to draw using instancing.
+//    class InstancedMesh {
+//
+//        /// The mesh that is shared across the instances.
+//        let mesh: Mesh
+//        /// Flag indicating if the mesh is transparent or not
+//        let transparent: Bool
+//        /// The instance indexes.
+//        let instances: [UInt32]
+//        /// Provides an offset into the instances buffer.
+//        var baseInstance: Int
+//
+//        /// Initalizes the instanced mesh.
+//        /// - Parameters:
+//        ///   - mesh: the mesh that should be instanced
+//        ///   - transparent: a flag indicating if the instance is transparent or not (used primarily for sorting).
+//        ///   - instances: the instance indexes
+//        ///   - baseInstance: the offset used by the GPU used to lookup the starting index into the instances buffer.
+//        init(mesh: Mesh, transparent: Bool, instances: [UInt32], _ baseInstance: Int = 0) {
+//            self.mesh = mesh
+//            self.transparent = transparent
+//            self.instances = instances
+//            self.baseInstance = baseInstance
+//        }
+//    }
+//
+//    public struct Submesh {
+//
+//        /// The range of values in the index buffer to define the geometry of its triangular faces in local space.
+//        ///
+//        /// For example: `let indices = geometry.indices[submesh.indices]`
+//        public var indices: Range<Int>
+//
+//        /// The submesh's byte offset into the index buffer.
+//        public var indexBufferOffset: Int {
+//            indices.lowerBound * MemoryLayout<UInt32>.size
+//        }
+//
+//        /// The mesh material.
+//        public var material: Material?
+//
+//        /// Initializes the submesh.
+//        ///
+//        /// - Parameters:
+//        ///   - indices: The range of values in the index buffer.
+//        ///   - material: The submesh's material.
+//        init(indices: Range<Int>, material: Material? = nil) {
+//            self.indices = indices
+//            self.material = material
+//        }
+//    }
+//
+//    /// A type that holds material information.
+//    public struct Material {
+//
+//        /// The material glossiness in the domain of [0.0...0.1]
+//        public var glossiness: Float = .zero
+//
+//        /// The material smoothness in the domain of [0.0...0.1]
+//        public var smoothness: Float = .zero
+//
+//        /// The material RGBA diffuse color with components in the domain of [0.0...0.1]
+//        public var rgba: SIMD4<Float> = .zero
+//    }
+//
+//    /// A type that holds geometric shape information.
+//    public struct Shape {
+//
+//        /// The shape RGBA color with components in the domain of [0.0...0.1]
+//        public var rgba: SIMD4<Float> = .zero
+//
+//        /// The width of the shape
+//        public var width: Float
+//
+//        /// References a slice of vertices in the shape vertex buffer.
+//        ///
+//        /// For example: `let vertices = geometry.shapeVertexBuffer[shape.indices]`
+//        public var indices: Range<Int>
+//    }
+//}

--- a/Sources/VimKit/Geometry+Raycasting.swift
+++ b/Sources/VimKit/Geometry+Raycasting.swift
@@ -6,7 +6,7 @@
 //
 
 import MetalKit
-import simd
+import VimKitShaders
 
 extension Geometry {
 
@@ -148,7 +148,7 @@ extension Geometry {
 
 // MARK: Instance Querying
 
-extension Geometry.Instance {
+extension Instance {
 
     /// Performs an intersection test of the instance against the query.
     /// See: https://metalbyexample.com/picking-hit-testing/

--- a/Sources/VimKit/Geometry+Spatial.swift
+++ b/Sources/VimKit/Geometry+Spatial.swift
@@ -133,9 +133,9 @@ extension Geometry {
         init(_ geometry: Geometry) async {
             self.geometry = geometry
             var data = [(index: Int, box: MDLAxisAlignedBoundingBox)]()
-            for (i, instance) in geometry.instances.enumerated() {
+            for instance in geometry.instances {
                 guard instance.boundingBox != .zero else { continue }
-                data.append((index: i, box: instance.boundingBox))
+                data.append((index: Int(instance.index), box: instance.boundingBox))
             }
             root = Node(&data)
         }

--- a/Sources/VimKit/Geometry+Spatial.swift
+++ b/Sources/VimKit/Geometry+Spatial.swift
@@ -134,12 +134,8 @@ extension Geometry {
             self.geometry = geometry
             var data = [(index: Int, box: MDLAxisAlignedBoundingBox)]()
             for (i, instance) in geometry.instances.enumerated() {
-                if let box = instance.boundingBox {
-                    data.append((index: i, box: box))
-                } else {
-                    guard let box = await geometry.calculateBoundingBox(instance) else { continue }
-                    data.append((index: i, box: box))
-                }
+                guard instance.boundingBox != .zero else { continue }
+                data.append((index: i, box: instance.boundingBox))
             }
             root = Node(&data)
         }

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -567,41 +567,6 @@ public class Geometry: ObservableObject, @unchecked Sendable {
         return instancesBuffer!.toUnsafeMutableBufferPointer()
     }()
 
-    /// Builds an array of instanced mesh structures (used for instancing).
-//    lazy var instancedMeshes: [InstancedMesh] = {
-//        var results = [InstancedMesh]()
-//
-//        // Build a map of instances that share the same mesh
-//        var meshInstances = [Int32: [UInt32]]()
-//        for instance in instances {
-//            guard instance.mesh != .empty else { continue }
-//            let mesh = instance.mesh
-//            if meshInstances[mesh] != nil {
-//                meshInstances[mesh]?.append(UInt32(instance.index))
-//             } else {
-//                 meshInstances[mesh] = [UInt32(instance.index)]
-//             }
-//        }
-//
-//        for (i, instances) in meshInstances {
-//            let mesh = meshes[i]
-//            let transparent = isTransparent(i)
-//            let meshInstances = InstancedMesh(mesh: mesh, transparent: transparent, instances: instances)
-//            results.append(meshInstances)
-//        }
-//
-//        // Sort the meshes by opaques and transparents
-//        results.sort{ !$0.transparent && $1.transparent }
-//
-//        // Set the base instance offsets
-//        var baseInstance: Int = 0
-//        for result in results {
-//            result.baseInstance = baseInstance
-//            baseInstance += result.instances.count
-//        }
-//        return results
-//    }()
-
     /// Determines mesh transparency. This allows us to sort or
     /// split instances into opaque or transparent continuous ranges.
     /// - Parameters:
@@ -618,14 +583,6 @@ public class Geometry: ObservableObject, @unchecked Sendable {
         guard alphas.isNotEmpty else { return true }
         return alphas[0] < 1.0
 
-//        guard let mesh, let range = mesh.submeshes else { return true }
-
-        // Find the lowest alpha value to determine transparency
-//        let alpha = range
-//            .map { submeshes[$0] }
-//            .sorted { $0.material?.rgba.w ?? .zero < $1.material?.rgba.w ?? .zero }
-//            .first?.material?.rgba.w ?? .zero
-//        return alpha < 1.0
     }
 
     func calculateBoundingBoxes() async {

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -7,8 +7,6 @@
 import Combine
 import Foundation
 import MetalKit
-import simd
-import SwiftUI
 import VimKitShaders
 
 // The MPS function name for computing the vertex normals on the GPU
@@ -35,19 +33,25 @@ public class Geometry: ObservableObject, @unchecked Sendable {
 
     /// Progress Reporting for loading the geometry data.
     @MainActor
-    public dynamic let progress = Progress(totalUnitCount: 10)
+    public dynamic let progress = Progress(totalUnitCount: 9)
 
     @MainActor @Published
     public var state: State = .unknown
 
-    /// Returns the combinded positions (vertex) buffer of all of the vertices for all the meshes layed out in slices of [x,y,z]
+    /// Returns the combined positions (vertex) buffer of all of the vertices for all the meshes layed out in slices of [x,y,z]
     public private(set) var positionsBuffer: MTLBuffer?
-    /// Returns the combinded index buffer of all of the indices.
+    /// Returns the combined index buffer of all of the indices.
     public private(set) var indexBuffer: MTLBuffer?
-    /// Returns the combinded buffer of all of the normals.
+    /// Returns the combined buffer of all of the normals.
     public private(set) var normalsBuffer: MTLBuffer?
-    /// Returns the combinded buffer of all of the instance transforms and their state information.
+    /// Returns the combined buffer of all of the instance transforms and their state information.
     public private(set) var instancesBuffer: MTLBuffer?
+    /// Returns the combined buffer of all of the materials.
+    public private(set) var materialsBuffer: MTLBuffer?
+    /// Returns the combined buffer of all of the submeshes.
+    public private(set) var submeshesBuffer: MTLBuffer?
+    /// Returns the combined buffer of all of the meshes.
+    public private(set) var meshesBuffer: MTLBuffer?
     /// Returns the combinded buffer of all of the color overrides that can be applied to each instance.
     public private(set) var colorsBuffer: MTLBuffer?
 
@@ -111,19 +115,13 @@ public class Geometry: ObservableObject, @unchecked Sendable {
         let cacheDir = FileManager.default.cacheDirectory
 
         // 1) Build the positions (vertex) buffer
-        let positions = attributes(association: .vertex, semantic: .position)
-        guard let positionsBuffer = positions.makeBuffer(device: device, type: Float.self) else {
-            fatalError("💀 Unable to create positions buffer")
-        }
-        self.positionsBuffer = positionsBuffer
+        makePositionsBuffer(device: device)
+        _ = positions
         incrementProgressCount()
 
         // 2) Build the index buffer
-        let indices = attributes(association: .corner, semantic: .index)
-        guard let indexBuffer = indices.makeBuffer(device: device, type: UInt32.self) else {
-            fatalError("💀 Unable to create index buffer")
-        }
-        self.indexBuffer = indexBuffer
+        makeIndexBuffer(device: device)
+        _ = indices
         incrementProgressCount()
 
         // 3) Build the normals buffer
@@ -131,22 +129,30 @@ public class Geometry: ObservableObject, @unchecked Sendable {
         incrementProgressCount()
 
         // 4) Build all the data structures
+        await makeMaterialsBuffer(device: device)
         _ = materials // Build the materials
         incrementProgressCount()
+
+        await makeSubmeshesBuffer(device: device)
         _ = submeshes // Build the submeshes
         incrementProgressCount()
+
+        await makeMeshesBuffer(device: device)
         _ = meshes // Build the meshes
         incrementProgressCount()
-        _ = instances // Build the instances
-        incrementProgressCount()
 
-        // 5) Build the instances buffer
         await makeInstancesBuffer(device: device)
+        _ = instances  // Build the instances
         _ = instancedMeshesMap
         incrementProgressCount()
 
+        await calculateBoundingBoxes()
+
+        assert(instancedMeshes.count == meshes.count, "💩 The instanced meshes [\(instancedMeshes.count)] and meshes [\(meshes.count)] count should be the same.")
+
         // 6) Build the colors buffer
         await makeColorsBuffer(device: device)
+        _ = colors
         incrementProgressCount()
 
         // Start indexing the file
@@ -175,6 +181,14 @@ public class Geometry: ObservableObject, @unchecked Sendable {
 
     // MARK: Postions (Vertex Buffer Raw Data)
 
+    private func makePositionsBuffer(device: MTLDevice) {
+        let positions = attributes(association: .vertex, semantic: .position)
+        guard let positionsBuffer = positions.makeBuffer(device: device, type: Float.self) else {
+            fatalError("💀 Unable to create positions buffer")
+        }
+        self.positionsBuffer = positionsBuffer
+    }
+
     /// Returns the combinded vertex buffer of all of the vertices for all the meshes layed out in slices of [x,y,z].
     public lazy var positions: UnsafeMutableBufferPointer<Float> = {
         assert(positionsBuffer != nil, "💩 Misuse [positions]")
@@ -182,6 +196,15 @@ public class Geometry: ObservableObject, @unchecked Sendable {
     }()
 
     // MARK: Index Buffer
+
+    private func makeIndexBuffer(device: MTLDevice) {
+        let indices = attributes(association: .corner, semantic: .index)
+
+        guard let indexBuffer = indices.makeBuffer(device: device, type: UInt32.self) else {
+            fatalError("💀 Unable to create index buffer")
+        }
+        self.indexBuffer = indexBuffer
+    }
 
     /// Returns the combined index buffer of all the meshes (one index per corner, and per half-edge).
     /// The values in this index buffer are relative to the beginning of the vertex buffer.
@@ -265,44 +288,24 @@ public class Geometry: ObservableObject, @unchecked Sendable {
         self.normalsBuffer = normalsBuffer
     }
 
-    /// Makes the instance buffer.
-    /// - Parameters:
-    ///   - device: the metal device to use
-    private func makeInstancesBuffer(device: MTLDevice) async {
-
-        guard !Task.isCancelled else { return }
-
-        // Build the array of instances
-        var instanced = instanceOffsets.map {
-            Instances(index: $0,
-                      colorIndex: .empty,
-                      matrix: instances[Int($0)].matrix,
-                      state: instances[Int($0)].flags != .zero ? .hidden : .default
-            )
-        }
-
-        // Make the metal buffer
-        guard let instancesBuffer = device.makeBuffer(
-            bytes: &instanced,
-            length: MemoryLayout<Instances>.stride * instanced.count) else {
-            fatalError("💀 Unable to create instances buffer")
-        }
-        self.instancesBuffer = instancesBuffer
-    }
-
     /// Makes the color overrides buffer
     /// - Parameter device: the metal device to use
     private func makeColorsBuffer(device: MTLDevice) async {
         guard !Task.isCancelled else { return }
         var colors = [SIMD4<Float>](repeating: .zero, count: maxColorOverrides)
-        colors[0] = Color.objectSelectionColor.channels // Set the first color override as the selection color
-        guard let colorsBuffer = device.makeBuffer(
+
+        //colors[0] = SwiftUI.Color.objectSelectionColor.channels // Set the first color override as the selection color
+        self.colorsBuffer = device.makeBuffer(
             bytes: &colors,
-            length: MemoryLayout<SIMD4<Float>>.stride * colors.count, options: [.storageModeShared]) else {
-            fatalError("💀 Unable to create colors buffer")
-        }
-        self.colorsBuffer = colorsBuffer
+            length: MemoryLayout<SIMD4<Float>>.stride * colors.count, options: [.storageModeShared])
     }
+
+    /// Returns the color overrides.
+    public lazy var colors: UnsafeMutableBufferPointer<SIMD4<Float>> = {
+        assert(colorsBuffer != nil, "💩 Misuse [colors]")
+        return colorsBuffer!.toUnsafeMutableBufferPointer()
+    }()
+
 
     /// Calculates the vertex normals.
     /// TODO: Port this over to Metal Performance Shaders to perform this work on the GPU.
@@ -387,14 +390,12 @@ public class Geometry: ObservableObject, @unchecked Sendable {
 
     // MARK: Meshes
 
-    /// The index offsets of a submesh in a given mesh
-    lazy var meshSubmeshOffsets: [Int32] = {
-        let attributes = attributes(association: .mesh, semantic: .submeshoffset)
-        return attributes.data.unsafeTypeArray()
-    }()
+    /// Makes the meshes buffer
+    /// - Parameter device: the metal device to use.
+    private func makeMeshesBuffer(device: MTLDevice) async {
+        guard !Task.isCancelled else { return }
 
-    /// Constructs the meshes from their data blocks
-    public lazy var meshes: [Mesh] = {
+        let meshSubmeshOffsets: [Int32] = unsafeTypeArray(association: .mesh, semantic: .submeshoffset)
         var meshes = [Mesh]()
 
         for (i, offset) in meshSubmeshOffsets.enumerated() {
@@ -403,30 +404,30 @@ public class Geometry: ObservableObject, @unchecked Sendable {
             let start = Int(offset)
             let nextOffset = i < meshSubmeshOffsets.endIndex - 1 ? meshSubmeshOffsets[Int(i+1)] : meshSubmeshOffsets.last!
             let end = i < meshSubmeshOffsets.endIndex - 1 ? Int(nextOffset): Int(meshSubmeshOffsets.last!)
-            let submeshRange: Range<Int> = start..<end
+            let range: Range<Int> = start..<end
 
             // Build the mesh
-            let mesh = Mesh(submeshes: submeshRange)
+            let mesh = Mesh(range)
             meshes.append(mesh)
         }
-        return meshes
+
+        self.meshesBuffer = device.makeBuffer(bytes: &meshes, length: MemoryLayout<Mesh>.stride * meshes.count, options: [.storageModeShared])
+    }
+
+    /// Returns the meshes from it's uderlying metal buffer.
+    public lazy var meshes: UnsafeMutableBufferPointer<Mesh> = {
+        assert(meshesBuffer != nil, "💩 Misuse [meshes]")
+        return meshesBuffer!.toUnsafeMutableBufferPointer()
     }()
 
     // MARK: Submeshes
 
-    /// References a slice of values in the index buffer to define the geometry of its triangular faces in local space.
-    lazy var submeshIndexOffsets: [Int32] = {
-        let attributes = attributes(association: .submesh, semantic: .indexoffset)
-        return attributes.data.unsafeTypeArray()
-    }()
+    private func makeSubmeshesBuffer(device: MTLDevice) async {
+        guard !Task.isCancelled else { return }
 
-    lazy var submeshMaterials: [Int32] = {
-        let attributes = attributes(association: .submesh, semantic: .material)
-        return attributes.data.unsafeTypeArray()
-    }()
+        let submeshIndexOffsets: [Int32] = unsafeTypeArray(association: .submesh, semantic: .indexoffset)
+        let submeshMaterials: [Int32] = unsafeTypeArray(association: .submesh, semantic: .material)
 
-    ///  Constructs all of the Submeshes from their associated data blocks.
-    public lazy var submeshes: [Submesh] = {
         var submeshes = [Submesh]()
 
         for (i, offset) in submeshIndexOffsets.enumerated() {
@@ -435,25 +436,26 @@ public class Geometry: ObservableObject, @unchecked Sendable {
             let start = Int(offset)
             let nextOffset = i < submeshIndexOffsets.endIndex - 1 ? submeshIndexOffsets[Int(i+1)] : submeshIndexOffsets.last!
             let end = i < submeshIndexOffsets.endIndex - 1 ? Int(nextOffset): Int(submeshIndexOffsets.last!)
-            let indicesRange: Range<Int> = start..<end
+            let range: Range<Int> = start..<end
 
-            // Grab the submesh material (an empty value of -1 denotes no material)
-            var material: Material?
-            let materialsOffset = submeshMaterials[i]
-            if materialsOffset != .empty {
-                material = materials[Int(materialsOffset)]
-            }
-
-            let submesh = Submesh(indices: indicesRange, material: material)
+            let material = submeshMaterials[i]
+            let submesh = Submesh(material, range)
             submeshes.append(submesh)
         }
-        return submeshes
+
+        self.submeshesBuffer = device.makeBuffer(bytes: &submeshes, length: MemoryLayout<Submesh>.stride * submeshes.count, options: [.storageModeShared])
+    }
+
+    ///  Constructs all of the Submeshes from their associated data blocks.
+    public lazy var submeshes: UnsafeMutableBufferPointer<Submesh> = {
+        assert(submeshesBuffer != nil, "💩 Misuse [submeshes]")
+        return submeshesBuffer!.toUnsafeMutableBufferPointer()
     }()
 
     // MARK: Instances
 
     /// Returns the 4x4 row-major transform matrix values associated with their respective instances.
-    private var instanceTransforms: [float4x4] {
+    private func instanceTransforms() -> [float4x4] {
         var results = [float4x4]()
         let attributes = attributes(association: .instance, semantic: .transform)
         for attribute in attributes {
@@ -471,83 +473,13 @@ public class Geometry: ObservableObject, @unchecked Sendable {
         return results
     }
 
-    /// Builds the array of instances.
-    public lazy var instances: [Instance] = {
-        var instances = [Instance]()
+    /// Holds an array of instanced mesh structures (used for instancing).
+    private(set) var instancedMeshes = [InstancedMesh]()
 
-        let instanceFlags: [Int16] = unsafeTypeArray(association: .instance, semantic: .flags)
-        let instanceParents: [Int32] = unsafeTypeArray(association: .instance, semantic: .parent)
-        let instanceMeshes: [Int32] = unsafeTypeArray(association: .instance, semantic: .mesh)
-        let transforms = instanceTransforms
+    /// Holds a set of hidden instanced meshes.
+    private(set) var hiddeninstancedMeshes = Set<Int>()
 
-        // Build the base instances
-        for (i, transform) in transforms.enumerated() {
-
-            var flags: Int16 = 0
-            if instanceFlags.indices.contains(i) {
-                flags = instanceFlags[i]
-            }
-
-            let instance = Instance(index: i, matrix: transform, flags: flags)
-
-            // Lookup the instance mesh
-            let meshOffset = instanceMeshes[i]
-            if meshOffset != .empty {
-                instance.mesh = meshes[Int(meshOffset)]
-            }
-
-            // Calculate the bounding box of the instance async
-            Task {
-                instance.boundingBox = await calculateBoundingBox(instance)
-            }
-            instance.transparent = isTransparent(instance.mesh)
-            instances.append(instance)
-        }
-
-        // Set the instance parent (if one)
-        for (i, offset) in instanceParents.enumerated() {
-            if offset != .empty {
-                let parent = instances[Int(offset)]
-                instances[i].parent = parent
-            }
-        }
-        return instances
-    }()
-
-    /// Builds an array of instanced mesh structures (used for instancing).
-    lazy var instancedMeshes: [InstancedMesh] = {
-        var results = [InstancedMesh]()
-
-        // Build a map of instances that share the same mesh
-        var meshInstances = [Mesh: [UInt32]]()
-        for instance in instances {
-            guard let mesh = instance.mesh else { continue }
-            if meshInstances[mesh] != nil {
-                meshInstances[mesh]?.append(UInt32(instance.index))
-             } else {
-                 meshInstances[mesh] = [UInt32(instance.index)]
-             }
-        }
-
-        for (mesh, instances) in meshInstances {
-            let transparent = isTransparent(mesh)
-            let meshInstances = InstancedMesh(mesh: mesh, transparent: transparent, instances: instances)
-            results.append(meshInstances)
-        }
-
-        // Sort the meshes by opaques and transparents
-        results.sort{ !$0.transparent && $1.transparent }
-
-        // Set the base instance offsets
-        var baseInstance: Int = 0
-        for result in results {
-            result.baseInstance = baseInstance
-            baseInstance += result.instances.count
-        }
-        return results
-    }()
-
-    /// Returns the instance offsets (used for instancing). 
+    /// Returns the instance offsets (used for instancing).
     lazy var instanceOffsets: [UInt32] = {
         instancedMeshes.map { $0.instances }.reduce( [], + )
     }()
@@ -565,23 +497,144 @@ public class Geometry: ObservableObject, @unchecked Sendable {
         return map
     }()
 
-    /// Holds a set of hidden instanced meshes.
-    var hiddeninstancedMeshes = Set<Int>()
+    /// Makes the instance buffer.
+    /// - Parameters:
+    ///   - device: the metal device to use
+    private func makeInstancesBuffer(device: MTLDevice) async {
+
+        guard !Task.isCancelled else { return }
+
+        var instances = [Instance]()
+        var meshInstances = [Int32: [UInt32]]()
+
+        let instanceFlags: [Int16] = unsafeTypeArray(association: .instance, semantic: .flags)
+        let instanceParents: [Int32] = unsafeTypeArray(association: .instance, semantic: .parent)
+        let instanceMeshes: [Int32] = unsafeTypeArray(association: .instance, semantic: .mesh)
+        let transforms = instanceTransforms()
+
+        // 1) Build the array of instances
+        for (i, transform) in transforms.enumerated() {
+
+            var flags: Int16 = 0
+            if instanceFlags.indices.contains(i) {
+                flags = instanceFlags[i]
+            }
+
+            let mesh = instanceMeshes[i]
+            let parent = instanceParents[i]
+            let transparent = isTransparent(mesh)
+            let instance = Instance(index: i, matrix: transform, flags: flags, parent: parent, mesh: mesh, transparent: transparent)
+            instances.append(instance)
+
+            guard mesh != .empty else { continue }
+
+            // Add this instance to the mesh map
+            if meshInstances[mesh] != nil {
+                meshInstances[mesh]?.append(instance.index)
+            } else {
+                meshInstances[mesh] = [instance.index]
+            }
+        }
+
+        // 2) Build the array of instanced meshes
+        for (i, instances) in meshInstances {
+            let mesh = meshes[i]
+            let transparent = isTransparent(i)
+            let meshInstances = InstancedMesh(mesh: mesh, transparent: transparent, instances: instances)
+            instancedMeshes.append(meshInstances)
+        }
+
+        // 3) Sort the instanced meshes by opaques and transparents
+        instancedMeshes.sort{ !$0.transparent && $1.transparent }
+
+        // 4) Set the base instance offsets
+        var baseInstance: Int = 0
+        for result in instancedMeshes {
+            result.baseInstance = baseInstance
+            baseInstance += result.instances.count
+        }
+
+        // 5) Use the instance offsets as our sorting mechanism
+        var instanced = instanceOffsets.map { instances[$0] }
+
+        // 6) Make the metal buffer
+        self.instancesBuffer = device.makeBuffer(bytes: &instanced, length: MemoryLayout<Instance>.stride * instanced.count)
+    }
+
+    /// Builds the array of instances.
+    public lazy var instances: UnsafeMutableBufferPointer<Instance> = {
+        assert(instancesBuffer != nil, "💩 Misuse [instances]")
+        return instancesBuffer!.toUnsafeMutableBufferPointer()
+    }()
+
+    /// Builds an array of instanced mesh structures (used for instancing).
+//    lazy var instancedMeshes: [InstancedMesh] = {
+//        var results = [InstancedMesh]()
+//
+//        // Build a map of instances that share the same mesh
+//        var meshInstances = [Int32: [UInt32]]()
+//        for instance in instances {
+//            guard instance.mesh != .empty else { continue }
+//            let mesh = instance.mesh
+//            if meshInstances[mesh] != nil {
+//                meshInstances[mesh]?.append(UInt32(instance.index))
+//             } else {
+//                 meshInstances[mesh] = [UInt32(instance.index)]
+//             }
+//        }
+//
+//        for (i, instances) in meshInstances {
+//            let mesh = meshes[i]
+//            let transparent = isTransparent(i)
+//            let meshInstances = InstancedMesh(mesh: mesh, transparent: transparent, instances: instances)
+//            results.append(meshInstances)
+//        }
+//
+//        // Sort the meshes by opaques and transparents
+//        results.sort{ !$0.transparent && $1.transparent }
+//
+//        // Set the base instance offsets
+//        var baseInstance: Int = 0
+//        for result in results {
+//            result.baseInstance = baseInstance
+//            baseInstance += result.instances.count
+//        }
+//        return results
+//    }()
 
     /// Determines mesh transparency. This allows us to sort or
     /// split instances into opaque or transparent continuous ranges.
     /// - Parameters:
     ///   - mesh: the mesh to determine transparency value for
     /// - Returns: true if the mesh is transparent, otherwise false
-    private func isTransparent(_ mesh: Mesh?) -> Bool {
-        guard let mesh, let range = mesh.submeshes else { return true }
+    private func isTransparent(_ index: Int32) -> Bool {
+
+        guard index != .empty else { return true }
+        let mesh = meshes[index]
+
+        let range = mesh.submeshes.range
+        let submeshe = submeshes[range].filter{ $0.material != .empty }
+        let alphas = submeshe.map { materials[$0.material].rgba.w }.sorted { $0 < $1 }
+        guard alphas.isNotEmpty else { return true }
+        return alphas[0] < 1.0
+
+//        guard let mesh, let range = mesh.submeshes else { return true }
 
         // Find the lowest alpha value to determine transparency
-        let alpha = range
-            .map { submeshes[$0] }
-            .sorted { $0.material?.rgba.w ?? .zero < $1.material?.rgba.w ?? .zero }
-            .first?.material?.rgba.w ?? .zero
-        return alpha < 1.0
+//        let alpha = range
+//            .map { submeshes[$0] }
+//            .sorted { $0.material?.rgba.w ?? .zero < $1.material?.rgba.w ?? .zero }
+//            .first?.material?.rgba.w ?? .zero
+//        return alpha < 1.0
+    }
+
+    func calculateBoundingBoxes() async {
+        for (i, instance) in instances.enumerated() {
+            Task {
+                guard let box = await calculateBoundingBox(instance) else { return }
+                instances[i].boundingBox = box
+            }
+        }
     }
 
     /// Calculates the bounding box for the specified instance.
@@ -626,7 +679,10 @@ public class Geometry: ObservableObject, @unchecked Sendable {
     /// - Parameter instance: the instance to return all of the vertices for
     /// - Returns: all vertices contained in the specified instance
     func vertices(for instance: Instance) -> [SIMD3<Float>]? {
-        guard let range = instance.mesh?.submeshes else { return nil }
+//        guard instance.mesh != .empty, let range = instance.mesh?.submeshes else { return nil }
+        guard instance.mesh != .empty else { return nil }
+        let mesh = meshes[instance.mesh]
+        let range = mesh.submeshes.range
         var results = [SIMD3<Float>]()
         let indexes = submeshes[range].map { indices[$0.indices].map { Int($0) * 3} }.reduce( [], + )
         for i in indexes {
@@ -689,42 +745,16 @@ public class Geometry: ObservableObject, @unchecked Sendable {
 
     // MARK: Materials
 
-    /// Returns the RGBA diffuse color of a given material in a value range of 0.0..1.0
-    lazy var materialColors: [SIMD4<Float>] = {
-        var results = [SIMD4<Float>]()
-        let attributes = attributes(association: .material, semantic: .color)
-        for attribute in attributes {
-            let array: [Float] = attribute.buffer.data.unsafeTypeArray()
-            let values = array.chunked(into: 4).map { SIMD4<Float>($0) }
-            results.append(contentsOf: values)
-        }
-        return results
-    }()
+    /// Makes the materials buffer.
+    /// - Parameter device: the metal device to use.
+    private func makeMaterialsBuffer(device: MTLDevice) async {
+        guard !Task.isCancelled else { return }
 
-    /// Returns an array of values from 0.0..1.0 representing the glossiness of a given material.
-    lazy var materialGlossiness: [Float] = {
-        var results = [Float]()
-        let attributes = attributes(association: .material, semantic: .glossiness)
-        for attribute in attributes {
-            let array: [Float] = attribute.buffer.data.unsafeTypeArray()
-            results.append(contentsOf: array)
-        }
-        return results
-    }()
+        let colors: [Float] = unsafeTypeArray(association: .material, semantic: .color)
+        let materialColors: [SIMD4<Float>] = colors.chunked(into: 4).map { SIMD4<Float>($0) }
+        let materialGlossiness: [Float] = unsafeTypeArray(association: .material, semantic: .glossiness)
+        let materialSmoothness: [Float] = unsafeTypeArray(association: .material, semantic: .smoothness)
 
-    /// Returns an array of values from 0.0..1.0 representing the smoothness of a given material.
-    lazy var materialSmoothness: [Float] = {
-        var results = [Float]()
-        let attributes = attributes(association: .material, semantic: .smoothness)
-        for attribute in attributes {
-            let array: [Float] = attribute.buffer.data.unsafeTypeArray()
-            results.append(contentsOf: array)
-        }
-        return results
-    }()
-
-    ///  Constructs all of the Materials from their associated data blocks.
-    public lazy var materials: [Material] = {
         var materials = [Material]()
         for (i, color) in materialColors.enumerated() {
             let glossiness = materialGlossiness[i]
@@ -732,7 +762,62 @@ public class Geometry: ObservableObject, @unchecked Sendable {
             let material = Material(glossiness: glossiness, smoothness: smoothness, rgba: color)
             materials.append(material)
         }
-        return materials
+
+        self.materialsBuffer = device.makeBuffer(
+            bytes: &materials,
+            length: MemoryLayout<Material>.stride * materials.count,
+            options: [.storageModeShared]
+        )
+    }
+
+    /// Returns the RGBA diffuse color of a given material in a value range of 0.0..1.0
+    /// 
+//    var materialColors: [SIMD4<Float>] = {
+//        var results = [SIMD4<Float>]()
+//        let attributes = attributes(association: .material, semantic: .color)
+//        for attribute in attributes {
+//            let array: [Float] = attribute.buffer.data.unsafeTypeArray()
+//            let values = array.chunked(into: 4).map { SIMD4<Float>($0) }
+//            results.append(contentsOf: values)
+//        }
+//        return results
+//    }()
+
+    /// Returns an array of values from 0.0..1.0 representing the glossiness of a given material.
+//    lazy var materialGlossiness: [Float] = {
+//        var results = [Float]()
+//        let attributes = attributes(association: .material, semantic: .glossiness)
+//        for attribute in attributes {
+//            let array: [Float] = attribute.buffer.data.unsafeTypeArray()
+//            results.append(contentsOf: array)
+//        }
+//        return results
+//    }()
+
+    /// Returns an array of values from 0.0..1.0 representing the smoothness of a given material.
+//    lazy var materialSmoothness: [Float] = {
+//        var results = [Float]()
+//        let attributes = attributes(association: .material, semantic: .smoothness)
+//        for attribute in attributes {
+//            let array: [Float] = attribute.buffer.data.unsafeTypeArray()
+//            results.append(contentsOf: array)
+//        }
+//        return results
+//    }()
+
+    ///  Returns the combined materials.
+    public lazy var materials: UnsafeMutableBufferPointer<Material> = {
+        assert(materialsBuffer != nil, "💩 Misuse [materials]")
+        return materialsBuffer!.toUnsafeMutableBufferPointer()
+
+//        var materials = [Material]()
+//        for (i, color) in materialColors.enumerated() {
+//            let glossiness = materialGlossiness[i]
+//            let smoothness = materialSmoothness[i]
+//            let material = Material(glossiness: glossiness, smoothness: smoothness, rgba: color)
+//            materials.append(material)
+//        }
+//        return materials
     }()
 
     /// Finds the attributes that have the specified association and semantic.
@@ -764,7 +849,7 @@ extension Geometry {
     ///   - ids: the ids of the instances to hide
     /// - Returns: the total count of hidden instances.
     public func hide(ids: [Int]) -> Int {
-        guard let pointer: UnsafeMutableBufferPointer<Instances> = instancesBuffer?.toUnsafeMutableBufferPointer() else { return 0 }
+        guard let pointer: UnsafeMutableBufferPointer<Instance> = instancesBuffer?.toUnsafeMutableBufferPointer() else { return 0 }
         for id in ids {
             guard let index = instanceOffsets.firstIndex(of: UInt32(id)) else { continue }
             pointer[index].state = .hidden
@@ -785,7 +870,7 @@ extension Geometry {
 
     /// Unhides all hidden instances.
     public func unhide() {
-        guard let pointer: UnsafeMutableBufferPointer<Instances> = instancesBuffer?.toUnsafeMutableBufferPointer() else { return }
+        guard let pointer: UnsafeMutableBufferPointer<Instance> = instancesBuffer?.toUnsafeMutableBufferPointer() else { return }
         for (i, value) in pointer.enumerated() {
             if value.state == .hidden {
                 pointer[i].state = .default
@@ -796,7 +881,7 @@ extension Geometry {
 
     /// Convenience var that returns a count of the hidden instances.
     public var hiddenCount: Int {
-        guard let pointer: UnsafeMutableBufferPointer<Instances> = instancesBuffer?.toUnsafeMutableBufferPointer() else { return 0 }
+        guard let pointer: UnsafeMutableBufferPointer<Instance> = instancesBuffer?.toUnsafeMutableBufferPointer() else { return 0 }
         return pointer[0..<pointer.count].filter{ $0.state == .hidden }.count
     }
 }
@@ -810,15 +895,14 @@ extension Geometry {
     ///   - id: the index of the instances to select or deselect
     /// - Returns: true if the instance was selected, otherwise false
     public func select(id: Int) -> Bool {
-        guard let pointer: UnsafeMutableBufferPointer<Instances> = instancesBuffer?.toUnsafeMutableBufferPointer(),
-              let index = instanceOffsets.firstIndex(of: UInt32(id)) else { return false }
-        let instance = pointer[index]
+        guard let index = instanceOffsets.firstIndex(of: UInt32(id)) else { return false }
+        let instance = instances[index]
         switch instance.state {
         case .default, .hidden:
-            pointer[index].state = .selected
+            instances[index].state = .selected
             return true
         case .selected:
-            pointer[index].state = .default
+            instances[index].state = .default
             return false
         @unknown default:
             return false
@@ -827,8 +911,7 @@ extension Geometry {
 
     /// Convenience var that returns a count of the selected instances.
     public var selectedCount: Int {
-        guard let pointer: UnsafeMutableBufferPointer<Instances> = instancesBuffer?.toUnsafeMutableBufferPointer() else { return 0 }
-        return pointer[0..<pointer.count].filter{ $0.state == .selected }.count
+        instances[0..<instances.count].filter{ $0.state == .selected }.count
     }
 }
 
@@ -849,8 +932,6 @@ extension Geometry {
     ///   - ids: the ids of the instances to apply this color override for
     public func apply(color: SIMD4<Float>, to ids: [Int]) {
 
-        guard let colors: UnsafeMutableBufferPointer<SIMD4<Float>> = colorsBuffer?.toUnsafeMutableBufferPointer() else { return }
-
         // Find the index of the color if it's already in the colors buffer
         var colorIndex: Int32 = 0
         if let index = colors.firstIndex(of: color) {
@@ -866,7 +947,6 @@ extension Geometry {
         }
 
         // Update the instances buffer with the color override index
-        guard let instances: UnsafeMutableBufferPointer<Instances> = instancesBuffer?.toUnsafeMutableBufferPointer() else { return }
         for id in ids {
             guard let index = instanceOffsets.firstIndex(of: UInt32(id)) else { continue }
             instances[index].colorIndex = colorIndex
@@ -876,7 +956,6 @@ extension Geometry {
     /// Unapplies the color override to all instances in the specified ids
     /// - Parameter ids: the ids of the instances to apply this color override for
     public func unapply(ids: [Int]) {
-        guard let instances: UnsafeMutableBufferPointer<Instances> = instancesBuffer?.toUnsafeMutableBufferPointer() else { return }
         var erasables = Set<Int>() // Collect the erasable color indices
         for id in ids {
             guard let index = instanceOffsets.firstIndex(of: UInt32(id)) else { continue }
@@ -896,7 +975,6 @@ extension Geometry {
         }
 
         // Finally, erase any unused color overrides
-        guard let colors: UnsafeMutableBufferPointer<SIMD4<Float>> = colorsBuffer?.toUnsafeMutableBufferPointer() else { return }
         for i in erasables {
             colors[i] = .zero
         }
@@ -904,14 +982,11 @@ extension Geometry {
 
     /// Removes all color overrides.
     public func unapplyAll() {
-        guard let instances: UnsafeMutableBufferPointer<Instances> = instancesBuffer?.toUnsafeMutableBufferPointer() else { return }
-
         // Erase all of the color indices from the instances
         for (i, _) in instances.enumerated() {
             instances[i].colorIndex = .empty
         }
 
-        guard let colors: UnsafeMutableBufferPointer<SIMD4<Float>> = colorsBuffer?.toUnsafeMutableBufferPointer() else { return }
         for (i, _) in colors.enumerated() {
             if i > 0 {
                 colors[i] = .zero

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -8,6 +8,7 @@ import Combine
 import Foundation
 import MetalKit
 import VimKitShaders
+import struct SwiftUICore.Color
 
 // The MPS function name for computing the vertex normals on the GPU
 private let computeVertexNormalsFunctionName = "computeVertexNormals"
@@ -825,7 +826,7 @@ extension Geometry {
         var colors = [SIMD4<Float>](repeating: .zero, count: maxColorOverrides)
 
         // Set the first color override as the selection color
-        colors[0] = .init(.objectSelection)
+        colors[0] = Color.objectSelectionColor.channels
         self.colorsBuffer = device.makeBuffer(
             bytes: &colors,
             length: MemoryLayout<SIMD4<Float>>.stride * colors.count, options: [.storageModeShared])

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -452,9 +452,8 @@ public class Geometry: ObservableObject, @unchecked Sendable {
 
         // 2) Build the array of instanced meshes
         for (i, instances) in meshInstances {
-            let mesh = meshes[i]
             let transparent = isTransparent(i)
-            let meshInstances = InstancedMesh(mesh: mesh, transparent: transparent, instances: instances)
+            let meshInstances = InstancedMesh(mesh: i, transparent: transparent, instances: instances)
             instancedMeshes.append(meshInstances)
         }
 

--- a/Sources/VimKit/Renderer/VimRenderer+Drawing.swift
+++ b/Sources/VimKit/Renderer/VimRenderer+Drawing.swift
@@ -136,14 +136,10 @@ public extension VimRenderer {
         let submeshes = geometry.submeshes[instanced.mesh.submeshes]
         for (i, submesh) in submeshes.enumerated() {
             guard submesh.material != .empty else { continue }
-            var material = geometry.materials[submesh.material]
-//            guard let material = submesh.material, material.rgba.w > .zero else { continue }
             renderEncoder.pushDebugGroup("SubMesh[\(i)]")
-            renderEncoder.setVertexBytes(&material, length: MemoryLayout<Material>.size, index: .materials)
 
-            // Set the mesh uniforms
-//            var uniforms = meshUniforms(submesh: submesh)
-//            renderEncoder.setVertexBytes(&uniforms, length: MemoryLayout<MeshUniforms>.size, index: .meshUniforms)
+            var material = geometry.materials[submesh.material]
+            renderEncoder.setVertexBytes(&material, length: MemoryLayout<Material>.size, index: .materials)
 
             // Draw the submesh
             drawSubmesh(geometry, submesh, renderEncoder, instanced.instances.count, instanced.baseInstance)
@@ -177,23 +173,6 @@ public extension VimRenderer {
     }
 }
 
-// MARK: Per Mesh Uniforms
-
-extension VimRenderer {
-
-    /// Returns the per mesh uniforms for the specifed submesh.
-    /// - Parameters:
-    ///   - submesh: the submesh
-    /// - Returns: the mesh unifroms
-//    func meshUniforms(submesh: Geometry.Submesh) -> MeshUniforms {
-//        MeshUniforms(
-//            color: submesh.material?.rgba ?? .zero,
-//            glossiness: submesh.material?.glossiness ?? .half,
-//            smoothness: submesh.material?.smoothness ?? .half
-//        )
-//    }
-}
-
 // MARK: Culling
 
 extension VimRenderer {
@@ -202,10 +181,9 @@ extension VimRenderer {
     /// - Parameter geometry: the geometry data
     /// - Returns: indices into the geometry.instancedMeshes that should be drawn
     private func cullInstancedMeshes(_ geometry: Geometry) -> [Int] {
-        Array(geometry.instancedMeshes.indices)
-//        guard let bvh = geometry.bvh, minFrustumCullingThreshold <= geometry.instancedMeshes.endIndex else {
-//            return Array(geometry.instancedMeshes.indices)
-//        }
-//        return bvh.intersectionResults(camera: camera)
+        guard let bvh = geometry.bvh, minFrustumCullingThreshold <= geometry.instancedMeshes.endIndex else {
+            return Array(geometry.instancedMeshes.indices)
+        }
+        return bvh.intersectionResults(camera: camera)
     }
 }

--- a/Sources/VimKit/Renderer/VimRenderer.swift
+++ b/Sources/VimKit/Renderer/VimRenderer.swift
@@ -151,11 +151,11 @@ extension VimRenderer {
         let query = camera.unprojectPoint(point)
         var point3D: SIMD3<Float> = .zero
 
-        // Raycast into the instance
-        if let result = geometry.instances[id].raycast(geometry, query: query) {
-            point3D = result.position
-            debugPrint("✅", point3D)
-        }
+//        // Raycast into the instance
+//        if let result = geometry.instances[id].raycast(geometry, query: query) {
+//            point3D = result.position
+//            debugPrint("✅", point3D)
+//        }
 
         // Select the instance so the event gets published.
         context.vim.select(id: id, point: point3D)

--- a/Sources/VimKit/Renderer/VimRenderer.swift
+++ b/Sources/VimKit/Renderer/VimRenderer.swift
@@ -146,16 +146,18 @@ extension VimRenderer {
             context.vim.erase()
             return
         }
+
         let id = Int(pixel)
+        guard let index = geometry.instanceOffsets.firstIndex(of: UInt32(pixel)) else { return }
 
         let query = camera.unprojectPoint(point)
         var point3D: SIMD3<Float> = .zero
 
-//        // Raycast into the instance
-//        if let result = geometry.instances[id].raycast(geometry, query: query) {
-//            point3D = result.position
-//            debugPrint("✅", point3D)
-//        }
+        // Raycast into the instance
+        if let result = geometry.instances[index].raycast(geometry, query: query) {
+            point3D = result.position
+            debugPrint("✅", point3D)
+        }
 
         // Select the instance so the event gets published.
         context.vim.select(id: id, point: point3D)

--- a/Sources/VimKit/Views/VimContainerView.swift
+++ b/Sources/VimKit/Views/VimContainerView.swift
@@ -32,7 +32,7 @@ public struct VimContainerView: UIViewRepresentable {
         // Render Pass Descriptor Options
         self.mtkView.colorPixelFormat = .rgba16Float
         self.mtkView.depthStencilPixelFormat = .depth32Float_stencil8
-        self.mtkView.clearColor = Color.skyBlue.mtlClearColor
+        self.mtkView.clearColor = Color(.skyBlue).mtlClearColor
         self.renderContext = VimContainerViewRendererContext(vim: vim, destinationProvider: mtkView)
     }
 

--- a/Sources/VimKit/Vim+Camera.swift
+++ b/Sources/VimKit/Vim+Camera.swift
@@ -275,7 +275,7 @@ extension Vim {
                 planes[.right] = matrix.columns.3 - matrix.columns.0
                 planes[.bottom] = matrix.columns.3 + matrix.columns.1
                 planes[.top] = matrix.columns.3 - matrix.columns.1
-                planes[.near] = matrix.columns.3 + matrix.columns.2
+                planes[.near] = matrix.columns.2
                 planes[.far] = matrix.columns.3 - matrix.columns.2
 
                 for (i, _) in planes.enumerated() {

--- a/Sources/VimKit/Vim.swift
+++ b/Sources/VimKit/Vim.swift
@@ -280,10 +280,6 @@ extension Vim {
         guard let geometry else { return }
         let selected = geometry.select(id: id)
         eventPublisher.send(.selected(id, selected, 1, point))
-//        DispatchQueue.main.async {
-//            // Publish the selection event
-//            self.eventPublisher.send(.selected(id, selected, 1, point))
-//        }
     }
 
     /// Toggles an instance hidden state for the instance with the specified id
@@ -295,10 +291,6 @@ extension Vim {
         guard let geometry else { return }
         let hiddenCount = geometry.hide(ids: ids)
         eventPublisher.send(.hidden(hiddenCount))
-//        DispatchQueue.main.async {
-//            // Publish the hidden event
-//            self.eventPublisher.send(.hidden(hiddenCount))
-//        }
     }
 
     /// Unhides all hidden instances.
@@ -307,9 +299,5 @@ extension Vim {
         guard let geometry else { return }
         geometry.unhide()
         eventPublisher.send(.hidden(0))
-//        DispatchQueue.main.async {
-//            // Publish the hidden event
-//            self.eventPublisher.send(.hidden(0))
-//        }
     }
 }

--- a/Sources/VimKit/Vim.swift
+++ b/Sources/VimKit/Vim.swift
@@ -229,41 +229,6 @@ public class Vim: NSObject, ObservableObject, @unchecked Sendable {
             self.progress.completedUnitCount += count
         }
     }
-
-    /// Validates the VIM file.
-    private func validate() {
-//
-//        guard let nodeTable = db?.Node else {
-//            assert(false, "The node table doesn't exist in the database")
-//            return
-//        }
-//
-//        var count = nodeTable.count
-//        guard let geometry = geometry else {
-//            assert(false, "The geometry block is absent")
-//            return
-//        }
-//
-//        guard let materialsTable = db?.Material else {
-//            assert(false, "The materials table doesn't exist in the database")
-//            return
-//        }
-//
-//        count = materialsTable.count
-//        assert(geometry.materialColors.count == count, "The number of material colors doesn't match the materials count.")
-//        assert(geometry.materialGlossiness.count == count, "The number of material glossiness doesn't match the materials count.")
-//        assert(geometry.materialSmoothness.count == count, "The number of material smoothness doesn't match the materials count.")
-//
-//        guard let shapesTable = db?.Shape else {
-//            assert(false, "The shapes table doesn't exist in the database")
-//            return
-//        }
-//
-//        count = shapesTable.count
-//        assert(geometry.shapeVertexOffsets.count == count, "The number of shape vertex offsets doesn't match the shapes count.")
-//        assert(geometry.shapeColors.count == count, "The number of shape colors doesn't match the shapes count.")
-//        assert(geometry.shapeWidths.count == count, "The number of shape widths doesn't match the shapes count.")
-    }
 }
 
 public extension Vim {

--- a/Sources/VimKit/Vim.swift
+++ b/Sources/VimKit/Vim.swift
@@ -232,37 +232,37 @@ public class Vim: NSObject, ObservableObject, @unchecked Sendable {
 
     /// Validates the VIM file.
     private func validate() {
-
-        guard let nodeTable = db?.Node else {
-            assert(false, "The node table doesn't exist in the database")
-            return
-        }
-
-        var count = nodeTable.count
-        guard let geometry = geometry else {
-            assert(false, "The geometry block is absent")
-            return
-        }
-
-        guard let materialsTable = db?.Material else {
-            assert(false, "The materials table doesn't exist in the database")
-            return
-        }
-
-        count = materialsTable.count
-        assert(geometry.materialColors.count == count, "The number of material colors doesn't match the materials count.")
-        assert(geometry.materialGlossiness.count == count, "The number of material glossiness doesn't match the materials count.")
-        assert(geometry.materialSmoothness.count == count, "The number of material smoothness doesn't match the materials count.")
-
-        guard let shapesTable = db?.Shape else {
-            assert(false, "The shapes table doesn't exist in the database")
-            return
-        }
-
-        count = shapesTable.count
-        assert(geometry.shapeVertexOffsets.count == count, "The number of shape vertex offsets doesn't match the shapes count.")
-        assert(geometry.shapeColors.count == count, "The number of shape colors doesn't match the shapes count.")
-        assert(geometry.shapeWidths.count == count, "The number of shape widths doesn't match the shapes count.")
+//
+//        guard let nodeTable = db?.Node else {
+//            assert(false, "The node table doesn't exist in the database")
+//            return
+//        }
+//
+//        var count = nodeTable.count
+//        guard let geometry = geometry else {
+//            assert(false, "The geometry block is absent")
+//            return
+//        }
+//
+//        guard let materialsTable = db?.Material else {
+//            assert(false, "The materials table doesn't exist in the database")
+//            return
+//        }
+//
+//        count = materialsTable.count
+//        assert(geometry.materialColors.count == count, "The number of material colors doesn't match the materials count.")
+//        assert(geometry.materialGlossiness.count == count, "The number of material glossiness doesn't match the materials count.")
+//        assert(geometry.materialSmoothness.count == count, "The number of material smoothness doesn't match the materials count.")
+//
+//        guard let shapesTable = db?.Shape else {
+//            assert(false, "The shapes table doesn't exist in the database")
+//            return
+//        }
+//
+//        count = shapesTable.count
+//        assert(geometry.shapeVertexOffsets.count == count, "The number of shape vertex offsets doesn't match the shapes count.")
+//        assert(geometry.shapeColors.count == count, "The number of shape colors doesn't match the shapes count.")
+//        assert(geometry.shapeWidths.count == count, "The number of shape widths doesn't match the shapes count.")
     }
 }
 

--- a/Sources/VimKitShaders/Resources/Compute.metal
+++ b/Sources/VimKitShaders/Resources/Compute.metal
@@ -4,8 +4,8 @@
 //
 //  Created by Kevin McKee
 //
-
 #include <metal_stdlib>
+#include "../include/ShaderTypes.h"
 using namespace metal;
 
 // Computes the vertex normals.
@@ -49,4 +49,18 @@ kernel void computeVertexNormals(device const float *positions,
         normals[j+1] = n.y;
         normals[j+2] = n.z;
     }
+}
+
+kernel void computeBoundingBoxes(device const float *positions,
+                                 device const uint32_t *indices,
+                                 device const Instance *instances,
+                                 device float3 *minBounds,
+                                 device float3 *maxBounds,
+                                 device float4x4 *transforms,
+                                 constant int &count) {
+    
+    for (int i = 0; i < count; i++) {
+        float4x4 transform = transforms[i];
+    }
+    
 }

--- a/Sources/VimKitShaders/Resources/Compute.metal
+++ b/Sources/VimKitShaders/Resources/Compute.metal
@@ -51,16 +51,63 @@ kernel void computeVertexNormals(device const float *positions,
     }
 }
 
+//let matrix = instance.matrix
+//let point: SIMD4<Float> = .init(vertices[0], 1.0)
+//let worldPoint = matrix * point
+//var minBounds = worldPoint.xyz
+//var maxBounds = worldPoint.xyz
+//for vertex in vertices {
+//    let point: SIMD4<Float> = .init(vertex, 1.0)
+//    let worldPoint = matrix * point
+//    minBounds = min(minBounds, worldPoint.xyz)
+//    maxBounds = max(maxBounds, worldPoint.xyz)
+//}
+//return MDLAxisAlignedBoundingBox(maxBounds: maxBounds, minBounds: minBounds)
+
+//func vertices(for instance: Instance) -> [SIMD3<Float>]? {
+////        guard instance.mesh != .empty, let range = instance.mesh?.submeshes else { return nil }
+//    guard instance.mesh != .empty else { return nil }
+//    let mesh = meshes[instance.mesh]
+//    let range = mesh.submeshes.range
+//    var results = [SIMD3<Float>]()
+//    let indexes = submeshes[range].map { indices[$0.indices].map { Int($0) * 3} }.reduce( [], + )
+//    for i in indexes {
+//        let vertex: SIMD3<Float> = .init(positions[i..<(i+3)])
+//        results.append(vertex)
+//    }
+//    return results
+//}
+
+
 kernel void computeBoundingBoxes(device const float *positions,
                                  device const uint32_t *indices,
                                  device const Instance *instances,
-                                 device float3 *minBounds,
-                                 device float3 *maxBounds,
-                                 device float4x4 *transforms,
+                                 device const Mesh *meshes,
+                                 device const Submesh *submeshes,
                                  constant int &count) {
     
     for (int i = 0; i < count; i++) {
-        float4x4 transform = transforms[i];
+        Instance instance = instances[i];
+        float4x4 transform = instance.matrix;
+        
+        if (instance.mesh == -1) { continue; }
+        
+        Mesh mesh = meshes[instance.mesh];
+        BoundedRange submeshRange = mesh.submeshes;
+        
+        for (uint j = submeshRange.lowerBound; j < submeshRange.upperBound; j++) {
+            Submesh submesh = submeshes[j];
+            BoundedRange indicesRange = submesh.indices;
+            int count = indicesRange.upperBound - indicesRange.lowerBound;
+            
+            for (uint k = indicesRange.lowerBound; k < indicesRange.upperBound; k++) {
+                uint index = indices[k] * 3;
+                float x = positions[index];
+                float y = positions[index+1];
+                float z = positions[index+2];
+                float3 position = float3(x, y, z);
+            }
+        }
     }
     
 }

--- a/Sources/VimKitShaders/Resources/Shaders.metal
+++ b/Sources/VimKitShaders/Resources/Shaders.metal
@@ -32,13 +32,13 @@ vertex VertexOut vertexMain(VertexIn in [[stage_in]],
                             uint vertex_id [[vertex_id]],
                             uint instance_id [[instance_id]],
                             constant UniformsArray &uniformsArray [[buffer(VertexBufferIndexUniforms)]],
-                            constant MeshUniforms &meshUniforms [[buffer(VertexBufferIndexMeshUniforms)]],
-                            constant Instances *instances [[buffer(VertexBufferIndexInstances)]],
+                            constant Material &material [[buffer(VertexBufferIndexMaterials)]],
+                            constant Instance *instances [[buffer(VertexBufferIndexInstances)]],
                             constant float4 *colors [[buffer(VertexBufferIndexColors)]],
                             constant bool &xRay [[buffer(VertexBufferIndexXRay)]]) {
 
     VertexOut out;
-    Instances instance = instances[instance_id];
+    Instance instance = instances[instance_id];
     uint instanceIndex = instance.index;
     int colorIndex = instance.colorIndex;
     
@@ -55,14 +55,14 @@ vertex VertexOut vertexMain(VertexIn in [[stage_in]],
     
     // Pass color information to the fragment shader
     float3 normal = in.normal.xyz;
-    out.glossiness = meshUniforms.glossiness;
-    out.smoothness = meshUniforms.smoothness;
-    out.color = meshUniforms.color;
+    out.glossiness = material.glossiness;
+    out.smoothness = material.smoothness;
+    out.color = material.rgba;
     
     // XRay the object
     if (xRay) {
-        float grayscale = 0.299 * meshUniforms.color.x + 0.587 * meshUniforms.color.y + 0.114 * meshUniforms.color.z;
-        float alpha = meshUniforms.color.w * 0.1;
+        float grayscale = 0.299 * material.rgba.x + 0.587 * material.rgba.y + 0.114 * material.rgba.z;
+        float alpha = material.rgba.w * 0.1;
         out.color = float4(grayscale, grayscale, grayscale, alpha);
     }
         

--- a/Sources/VimKitShaders/Resources/Shaders.metal
+++ b/Sources/VimKitShaders/Resources/Shaders.metal
@@ -23,22 +23,30 @@ constant float4 materialSpecularColor = float4(1.0, 1.0, 1.0, 1.0);
 //   - amp_id: The index into the uniforms array used for stereoscopic views in visionOS.
 //   - instance_id: The baseInstance parameter passed to the draw call used to map this instance to it's transform data.
 //   - uniformsArray: The per frame uniforms.
-//   - meshUniforms: The per mesh uniforms.
 //   - instances: The instances pointer.
+//   - meshes: The meshes pointer.
+//   - submeshes: The submeshes pointer.
+//   - materials: The materials pointer.
 //   - colors: The colors pointer used to apply custom color profiles to instances.
-//   - xRay: Flag indicating if this frame is being rendered in xray mode.
+//   - options: The frame rendering options.
 vertex VertexOut vertexMain(VertexIn in [[stage_in]],
                             ushort amp_id [[amplification_id]],
                             uint vertex_id [[vertex_id]],
                             uint instance_id [[instance_id]],
                             constant UniformsArray &uniformsArray [[buffer(VertexBufferIndexUniforms)]],
-                            constant Material &material [[buffer(VertexBufferIndexMaterials)]],
                             constant Instance *instances [[buffer(VertexBufferIndexInstances)]],
+                            constant Mesh *meshes [[buffer(VertexBufferIndexMeshes)]],
+                            constant Submesh *submeshes [[buffer(VertexBufferIndexSubmeshes)]],
+                            constant Material *materials [[buffer(VertexBufferIndexMaterials)]],
                             constant float4 *colors [[buffer(VertexBufferIndexColors)]],
-                            constant bool &xRay [[buffer(VertexBufferIndexXRay)]]) {
+                            constant Identifiers &identifiers [[buffer(VertexBufferIndexIdentifiers)]],
+                            constant RenderOptions &options [[buffer(VertexBufferIndexRenderOptions)]]) {
 
     VertexOut out;
     Instance instance = instances[instance_id];
+    Submesh submesh = submeshes[identifiers.submesh];
+    Material material = materials[submesh.material];
+    
     uint instanceIndex = instance.index;
     int colorIndex = instance.colorIndex;
     
@@ -60,7 +68,7 @@ vertex VertexOut vertexMain(VertexIn in [[stage_in]],
     out.color = material.rgba;
     
     // XRay the object
-    if (xRay) {
+    if (options.xRay) {
         float grayscale = 0.299 * material.rgba.x + 0.587 * material.rgba.y + 0.114 * material.rgba.z;
         float alpha = material.rgba.w * 0.1;
         out.color = float4(grayscale, grayscale, grayscale, alpha);

--- a/Sources/VimKitShaders/Resources/Shaders.metal
+++ b/Sources/VimKitShaders/Resources/Shaders.metal
@@ -142,5 +142,20 @@ fragment FragmentOut fragmentMain(VertexOut in [[stage_in]],
     return out;
 }
 
+// Extracts the six frustum planes determined by the provided matrix.
+// - Parameters:
+//   - matrix: the camera projectionMatrix * viewMatrix
+//   - planes: the planes pointer to write to
+static void extract_frustum_planes(constant float4x4 &matrix, thread float4 *planes) {
 
-
+    float4x4 mt = transpose(matrix);
+    planes[0] = mt[3] + mt[0]; // left
+    planes[1] = mt[3] - mt[0]; // right
+    planes[2] = mt[3] - mt[1]; // top
+    planes[3] = mt[3] + mt[1]; // bottom
+    planes[4] = mt[2];         // near
+    planes[5] = mt[3] - mt[2]; // far
+    for (int i = 0; i < 6; ++i) {
+        planes[i] /= length(planes[i].xyz);
+    }
+}

--- a/Sources/VimKitShaders/Resources/Shapes.metal
+++ b/Sources/VimKitShaders/Resources/Shapes.metal
@@ -17,8 +17,6 @@ using namespace metal;
 //   - uniformsArray: The per frame uniforms.
 //   - modelMatrix: The shape transform data
 //   - color: The shape color.
-//   - colorOverrides: The color overrides pointer used to apply custom color profiles to instances.
-//   - xRay: Flag indicating if this frame is being rendered in xray mode.
 vertex VertexOut vertexShape(VertexIn in [[stage_in]],
                              ushort amp_id [[amplification_id]],
                              uint vertex_id [[vertex_id]],

--- a/Sources/VimKitShaders/include/ShaderTypes.h
+++ b/Sources/VimKitShaders/include/ShaderTypes.h
@@ -21,6 +21,34 @@ typedef NSInteger EnumBackingType;
 // SWIFT/METAL STRUCTURES THAT ARE SHARED BETWEEN METAL SHADERS AND SWIFT
 //***********************************************************************
 
+typedef struct {
+    // The lower bounds of the range
+    uint32_t lowerBound;
+    // The upper bounds of the range
+    uint32_t upperBound;
+} BoundedRange;
+
+typedef struct {
+    /// The material glossiness in the domain of [0.0...0.1]
+    float glossiness;
+    /// The material smoothness in the domain of [0.0...0.1]
+    float smoothness;
+    /// The material RGBA diffuse color with components in the domain of [0.0...0.1]
+    simd_float4 rgba;
+} Material;
+
+typedef struct {
+    /// The material index (-1 indicates no material)
+    int32_t material;
+    /// The range of values in the index buffer to define the geometry of its triangular faces in local space.
+    BoundedRange indices;
+} Submesh;
+
+typedef struct {
+    /// The range of submeshes contained inside this mesh.
+    BoundedRange submeshes;
+} Mesh;
+
 // Per Frame Uniforms
 typedef struct {
     // Camera uniforms
@@ -34,13 +62,6 @@ typedef struct {
 typedef struct {
     Uniforms uniforms[2];
 } UniformsArray;
-
-// Per Mesh Uniforms
-typedef struct {
-    simd_float4 color;
-    float glossiness;
-    float smoothness;
-} MeshUniforms;
 
 // Enum constants for possible instance states
 typedef NS_ENUM(EnumBackingType, InstanceState) {
@@ -59,14 +80,24 @@ typedef struct {
     simd_float4x4 matrix;
     // The state of the instance
     InstanceState state;
-} Instances;
+    // The instance min bounds (in world space)
+    simd_float3 minBounds;
+    // The instance max bounds (in world space)
+    simd_float3 maxBounds;
+    // The parent index of the instance (-1 indicates no parent).
+    int32_t parent;
+    /// The mesh index (-1 indicates no mesh)
+    int32_t mesh;
+    /// Flag indicating if this instance is transparent or not.
+    bool transparent;
+} Instance;
 
 // Enum constants for the association of a specific buffer index argument passed into the shader vertex function
 typedef NS_ENUM(EnumBackingType, VertexBufferIndex) {
     VertexBufferIndexPositions = 0,
     VertexBufferIndexNormals = 1,
     VertexBufferIndexUniforms = 2,
-    VertexBufferIndexMeshUniforms = 3,
+    VertexBufferIndexMaterials = 3,
     VertexBufferIndexInstances = 4,
     VertexBufferIndexColors = 5,
     VertexBufferIndexXRay = 6

--- a/Sources/VimKitShaders/include/ShaderTypes.h
+++ b/Sources/VimKitShaders/include/ShaderTypes.h
@@ -29,23 +29,23 @@ typedef struct {
 } BoundedRange;
 
 typedef struct {
-    /// The material glossiness in the domain of [0.0...0.1]
+    // The material glossiness in the domain of [0.0...0.1]
     float glossiness;
-    /// The material smoothness in the domain of [0.0...0.1]
+    // The material smoothness in the domain of [0.0...0.1]
     float smoothness;
-    /// The material RGBA diffuse color with components in the domain of [0.0...0.1]
+    // The material RGBA diffuse color with components in the domain of [0.0...0.1]
     simd_float4 rgba;
 } Material;
 
 typedef struct {
-    /// The material index (-1 indicates no material)
+    // The material index (-1 indicates no material)
     int32_t material;
-    /// The range of values in the index buffer to define the geometry of its triangular faces in local space.
+    // The range of values in the index buffer to define the geometry of its triangular faces in local space.
     BoundedRange indices;
 } Submesh;
 
 typedef struct {
-    /// The range of submeshes contained inside this mesh.
+    // The range of submeshes contained inside this mesh.
     BoundedRange submeshes;
 } Mesh;
 
@@ -92,15 +92,31 @@ typedef struct {
     bool transparent;
 } Instance;
 
+typedef struct {
+    // Flag indicating if this frame is being rendered in xray mode.
+    bool xRay;
+} RenderOptions;
+
+// A type that holds identifier information about what is currently being rendered.
+typedef struct {
+    // The index of the mesh being drawn
+    int mesh;
+    // The index of the submesh being drawn
+    int submesh;
+} Identifiers;
+
 // Enum constants for the association of a specific buffer index argument passed into the shader vertex function
 typedef NS_ENUM(EnumBackingType, VertexBufferIndex) {
     VertexBufferIndexPositions = 0,
     VertexBufferIndexNormals = 1,
     VertexBufferIndexUniforms = 2,
-    VertexBufferIndexMaterials = 3,
-    VertexBufferIndexInstances = 4,
-    VertexBufferIndexColors = 5,
-    VertexBufferIndexXRay = 6
+    VertexBufferIndexInstances = 3,
+    VertexBufferIndexMeshes = 4,
+    VertexBufferIndexSubmeshes = 5,
+    VertexBufferIndexMaterials = 6,
+    VertexBufferIndexColors = 7,
+    VertexBufferIndexIdentifiers = 8,
+    VertexBufferIndexRenderOptions = 9
 };
 
 // Enum constances for the attribute index of an incoming vertex


### PR DESCRIPTION
# Description

* Moves **_ALL_** of the major data structures into the `VimKitShaders` module to allow seamless sharing of code between Swift and the Metal shaders. Extensions for these structures were created to make the higher level Swift code more friendly to work with.
	* `Material`
	* `Instance`
	* `Mesh`
	* `Submesh`
* The `Geometry` class now creates [MTLBuffers](https://developer.apple.com/documentation/metal/mtlbuffer) for the above data structures that are passed over to the main vertex shader. 
* Bounding Boxes are now being calculated on the GPU which offers `~ 85%` performance improvement.
	* `GPU Bounding boxes computed in [00:00:05.469]`
	* `CPU Bounding boxes computed in [00:00:38.511]`


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
