### PR TITLE
ShaderTypes

### DIFF
--- a/Sources/VimKit/Extensions/BoundedRange+Extensions.swift
+++ b/Sources/VimKit/Extensions/BoundedRange+Extensions.swift
@@ -20,7 +20,7 @@ extension BoundedRange: @retroactive Equatable, @retroactive Hashable {
     }
 
     init(_ range: Range<Int>) {
-        self.init(lowerBound: UInt32(range.lowerBound), upperBound: UInt32(range.upperBound))
+        self.init(lowerBound: range.lowerBound, upperBound: range.upperBound)
     }
 
     public static func == (lhs: BoundedRange, rhs: BoundedRange) -> Bool {

--- a/Sources/VimKit/Geometry+Mesh.swift
+++ b/Sources/VimKit/Geometry+Mesh.swift
@@ -11,11 +11,11 @@ import VimKitShaders
 class InstancedMesh {
 
     /// The mesh index that is shared across the instances.
-    let mesh: Int32
+    let mesh: Int
     /// Flag indicating if the mesh is transparent or not
     let transparent: Bool
     /// The instance indexes.
-    let instances: [UInt32]
+    let instances: [Int]
     /// Provides an offset into the instances buffer.
     var baseInstance: Int
 
@@ -25,8 +25,8 @@ class InstancedMesh {
     ///   - transparent: a flag indicating if the instance is transparent or not (used primarily for sorting).
     ///   - instances: the instance indexes
     ///   - baseInstance: the offset used by the GPU used to lookup the starting index into the instances buffer.
-    init(mesh: Int32, transparent: Bool, instances: [UInt32], _ baseInstance: Int = 0) {
-        self.mesh = mesh
+    init(mesh: Int32, transparent: Bool, instances: [Int], _ baseInstance: Int = 0) {
+        self.mesh = Int(mesh)
         self.transparent = transparent
         self.instances = instances
         self.baseInstance = baseInstance
@@ -54,14 +54,14 @@ extension Instance {
     ///   - mesh: the mesh index (-1 indicates this instance has no mesh)
     ///   - transparent: Flag indicating if the instance is transparent or not.
     init(index: Int, matrix: float4x4, flags: Int16, parent: Int32, mesh: Int32, transparent: Bool) {
-        self.init(index: UInt32(index),
+        self.init(index: index,
                   colorIndex: .empty,
                   matrix: matrix,
                   state: flags != .zero ? .hidden : .default,
                   minBounds: .zero,
                   maxBounds: .zero,
-                  parent: parent,
-                  mesh: mesh,
+                  parent: Int(parent),
+                  mesh: Int(mesh),
                   transparent: transparent
         )
     }
@@ -95,6 +95,6 @@ extension Submesh {
     ///   - material: The submesh's material index (-1 denotes no material).
     ///   - indices: The range of values in the index buffer.
     init(_ material: Int32, _ indices: Range<Int>) {
-        self.init(material: material, indices: .init(indices))
+        self.init(material: Int(material), indices: .init(indices))
     }
 }

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -395,7 +395,7 @@ public class Geometry: ObservableObject, @unchecked Sendable {
     private(set) var hiddeninstancedMeshes = Set<Int>()
 
     /// Returns the instance offsets (used for instancing).
-    lazy var instanceOffsets: [UInt32] = {
+    lazy var instanceOffsets: [Int] = {
         instancedMeshes.map { $0.instances }.reduce( [], + )
     }()
 
@@ -420,7 +420,7 @@ public class Geometry: ObservableObject, @unchecked Sendable {
         guard !Task.isCancelled else { return }
 
         var instances = [Instance]()
-        var meshInstances = [Int32: [UInt32]]()
+        var meshInstances = [Int32: [Int]]()
 
         let instanceFlags: [Int16] = unsafeTypeArray(association: .instance, semantic: .flags)
         let instanceParents: [Int32] = unsafeTypeArray(association: .instance, semantic: .parent)
@@ -753,7 +753,7 @@ extension Geometry {
     /// - Returns: the total count of hidden instances.
     public func hide(ids: [Int]) -> Int {
         for id in ids {
-            guard let index = instanceOffsets.firstIndex(of: UInt32(id)) else { continue }
+            guard let index = instanceOffsets.firstIndex(of: id) else { continue }
             instances[index].state = .hidden
         }
 
@@ -795,7 +795,7 @@ extension Geometry {
     ///   - id: the index of the instances to select or deselect
     /// - Returns: true if the instance was selected, otherwise false
     public func select(id: Int) -> Bool {
-        guard let index = instanceOffsets.firstIndex(of: UInt32(id)) else { return false }
+        guard let index = instanceOffsets.firstIndex(of: id) else { return false }
         let instance = instances[index]
         switch instance.state {
         case .default, .hidden:
@@ -846,14 +846,14 @@ extension Geometry {
     public func apply(color: SIMD4<Float>, to ids: [Int]) {
 
         // Find the index of the color if it's already in the colors buffer
-        var colorIndex: Int32 = 0
+        var colorIndex: Int = 0
         if let index = colors.firstIndex(of: color) {
             // Use the index of the found color
-            colorIndex = Int32(index)
+            colorIndex = index
         } else if let index = colors.firstIndex(of: .zero) {
             // Push the color into the first empty slot
             colors[index] = color
-            colorIndex = Int32(index)
+            colorIndex = index
         } else {
             // No empty color slots
             return
@@ -861,7 +861,7 @@ extension Geometry {
 
         // Update the instances buffer with the color override index
         for id in ids {
-            guard let index = instanceOffsets.firstIndex(of: UInt32(id)) else { continue }
+            guard let index = instanceOffsets.firstIndex(of: id) else { continue }
             instances[index].colorIndex = colorIndex
         }
     }
@@ -871,17 +871,17 @@ extension Geometry {
     public func unapply(ids: [Int]) {
         var erasables = Set<Int>() // Collect the erasable color indices
         for id in ids {
-            guard let index = instanceOffsets.firstIndex(of: UInt32(id)) else { continue }
+            guard let index = instanceOffsets.firstIndex(of: id) else { continue }
             let instance = instances[index]
             if instance.colorIndex != .empty {
-                erasables.insert(Int(instance.colorIndex))
+                erasables.insert(instance.colorIndex)
             }
             instances[index].colorIndex = .empty
         }
 
         // Check no other instances have a reference to the same color override
         for (_, value) in instances.enumerated() {
-            let index = Int(value.colorIndex)
+            let index = value.colorIndex
             if erasables.contains(index) {
                 erasables.remove(index)
             }

--- a/Sources/VimKit/Renderer/VimRenderer+Drawing.swift
+++ b/Sources/VimKit/Renderer/VimRenderer+Drawing.swift
@@ -140,7 +140,7 @@ public extension VimRenderer {
         let mesh = geometry.meshes[instanced.mesh]
         let submeshes = geometry.submeshes[mesh.submeshes]
         for (i, submesh) in submeshes.enumerated() {
-            let s = Int32(mesh.submeshes.range.lowerBound + i)
+            let s = mesh.submeshes.range.lowerBound + i
             renderEncoder.pushDebugGroup("SubMesh[\(s)]")
 
             // Set the identifiers of the mesh + submesh

--- a/Sources/VimKit/Renderer/VimRenderer.swift
+++ b/Sources/VimKit/Renderer/VimRenderer.swift
@@ -148,7 +148,7 @@ extension VimRenderer {
         }
 
         let id = Int(pixel)
-        guard let index = geometry.instanceOffsets.firstIndex(of: UInt32(pixel)) else { return }
+        guard let index = geometry.instanceOffsets.firstIndex(of: id) else { return }
 
         let query = camera.unprojectPoint(point)
         var point3D: SIMD3<Float> = .zero

--- a/Sources/VimKitShaders/include/ShaderTypes.h
+++ b/Sources/VimKitShaders/include/ShaderTypes.h
@@ -39,7 +39,7 @@ typedef struct {
 
 typedef struct {
     // The material index (-1 indicates no material)
-    int32_t material;
+    size_t material;
     // The range of values in the index buffer to define the geometry of its triangular faces in local space.
     BoundedRange indices;
 } Submesh;
@@ -73,9 +73,9 @@ typedef NS_ENUM(EnumBackingType, InstanceState) {
 // Instancing Data
 typedef struct {
     // The index of the instance.
-    uint32_t index;
+    size_t index;
     // The index of the color override to use from the colors buffer (-1 indicates no override)
-    int32_t colorIndex;
+    size_t colorIndex;
     // The 4x4 row-major matrix representing the node's world-space transform.
     simd_float4x4 matrix;
     // The state of the instance
@@ -85,9 +85,9 @@ typedef struct {
     // The instance max bounds (in world space)
     simd_float3 maxBounds;
     // The parent index of the instance (-1 indicates no parent).
-    int32_t parent;
+    size_t parent;
     /// The mesh index (-1 indicates no mesh)
-    int32_t mesh;
+    size_t mesh;
     /// Flag indicating if this instance is transparent or not.
     bool transparent;
 } Instance;
@@ -100,9 +100,9 @@ typedef struct {
 // A type that holds identifier information about what is currently being rendered.
 typedef struct {
     // The index of the mesh being drawn
-    int mesh;
+    size_t mesh;
     // The index of the submesh being drawn
-    int submesh;
+    size_t submesh;
 } Identifiers;
 
 // Enum constants for the association of a specific buffer index argument passed into the shader vertex function

--- a/Sources/VimKitShaders/include/ShaderTypes.h
+++ b/Sources/VimKitShaders/include/ShaderTypes.h
@@ -23,9 +23,9 @@ typedef NSInteger EnumBackingType;
 
 typedef struct {
     // The lower bounds of the range
-    uint32_t lowerBound;
+    size_t lowerBound;
     // The upper bounds of the range
-    uint32_t upperBound;
+    size_t upperBound;
 } BoundedRange;
 
 typedef struct {


### PR DESCRIPTION
# Description

Cleaned up the ShaderType structs to use `size_t` instead of fixed size integers to improve Swift interoperability.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
