### PR TITLE
visionOS 2.0

### DIFF
--- a/Sources/VimKit/Renderer/VimRenderer+Drawing.swift
+++ b/Sources/VimKit/Renderer/VimRenderer+Drawing.swift
@@ -125,7 +125,7 @@ public extension VimRenderer {
     /// Performs any draws after the main scene draw.
     /// - Parameter renderEncoder: the render encoder
     func didDrawScene(renderEncoder: MTLRenderCommandEncoder) {
-        skycube?.draw(renderEncoder: renderEncoder)
+        skycube?.draw(renderEncoder: renderEncoder, uniformBuffer: uniformBuffer, uniformBufferOffset: uniformBufferOffset, samplerState: samplerState)
         visibility?.draw(renderEncoder: renderEncoder)
     }
 

--- a/Sources/VimKit/Renderer/VimRenderer+Skycube.swift
+++ b/Sources/VimKit/Renderer/VimRenderer+Skycube.swift
@@ -123,7 +123,17 @@ extension VimRenderer {
 
         /// Draws the skycube.
         /// - Parameter renderEncoder: the render encoder to use.
-        func draw(renderEncoder: MTLRenderCommandEncoder) {
+
+        /// Draws the skycube.
+        /// - Parameters:
+        ///   - renderEncoder: the render encoder to use.
+        ///   - uniformBuffer: the uniform buffer
+        ///   - uniformBufferOffset: the uniform buffer offset
+        ///   - samplerState: the sampler state
+        func draw(renderEncoder: MTLRenderCommandEncoder,
+                  uniformBuffer: MTLBuffer,
+                  uniformBufferOffset: Int,
+                  samplerState: MTLSamplerState?) {
 
             guard let pipelineState else { return }
             renderEncoder.pushDebugGroup(skycubeGroupName)
@@ -131,8 +141,12 @@ extension VimRenderer {
             renderEncoder.setDepthStencilState(depthStencilState)
 
             // Set the buffers to pass to the GPU
-            renderEncoder.setVertexBuffer(mesh.vertexBuffers[0].buffer, offset: 0, index: .positions)
+            renderEncoder.setVertexBuffer(uniformBuffer, offset: uniformBufferOffset, index: .uniforms)
+            for (i, vertexBuffer) in mesh.vertexBuffers.enumerated() {
+                renderEncoder.setVertexBuffer(vertexBuffer.buffer, offset: vertexBuffer.offset, index: .positions)
+            }
             renderEncoder.setFragmentTexture(texture, index: 0)
+            renderEncoder.setFragmentSamplerState(samplerState, index: 0)
 
             let submesh = mesh.submeshes[0]
             renderEncoder.drawIndexedPrimitives(type: .triangle, indexCount: submesh.indexCount, indexType: submesh.indexType, indexBuffer: submesh.indexBuffer.buffer, indexBufferOffset: 0)

--- a/Sources/VimKit/Views/VimContainerView.swift
+++ b/Sources/VimKit/Views/VimContainerView.swift
@@ -9,6 +9,7 @@ import Combine
 import MetalKit
 import SwiftUI
 
+#if !os(visionOS)
 private struct VimContainerViewRendererContext: VimRendererContext {
 
     public var vim: Vim
@@ -83,3 +84,4 @@ public struct VimContainerView: ViewReprentable {
         mtkView.addGestureRecognizer(gesture)
     }
 }
+#endif

--- a/Sources/VimKit/Views/VimContainerViewCoordinator.swift
+++ b/Sources/VimKit/Views/VimContainerViewCoordinator.swift
@@ -8,6 +8,8 @@
 import GameController
 import MetalKit
 
+#if !os(visionOS)
+
 /// Provides a coordinator that is responsible for rendering into it's MTKView representable.
 @MainActor
 public class VimContainerViewCoordinator: NSObject, MTKViewDelegate {
@@ -128,3 +130,5 @@ extension VimContainerViewCoordinator {
         }
     }
 }
+
+#endif

--- a/Sources/VimKit/Vim+Camera.swift
+++ b/Sources/VimKit/Vim+Camera.swift
@@ -336,12 +336,8 @@ extension Vim.Camera {
         // Get the current device anchor
         guard let deviceAnchor = drawable.deviceAnchor else { return }
 
-        let view = drawable.views[index]
-        let tangents = view.tangents
-        let depthRange = drawable.depthRange
-
-        let projectiveTransform = ProjectiveTransform3D(tangents: tangents, depthRange: depthRange)
-        projectionMatrix = .init(projectiveTransform)
+        let projection = drawable.computeProjection(convention: .rightUpForward, viewIndex: index)
+        projectionMatrix = projection
         transform = sceneTransform * deviceAnchor.originFromAnchorTransform
         position *= velocity
         frustum.update(self)


### PR DESCRIPTION
# Description

- VisionOS macros to exclude the SwiftUI ViewRepresentables.
- Changed the projection matrix calculation to use the new API.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
