### PR TITLE
Compositor Fixes

### DIFF
--- a/Sources/VimKit/Views/VimRendererContainerViewCoordinator.swift
+++ b/Sources/VimKit/Views/VimRendererContainerViewCoordinator.swift
@@ -37,6 +37,10 @@ public class VimRendererContainerViewCoordinator: NSObject, MTKViewDelegate {
         self.viewRepresentable = viewRepresentable
         self.renderer = VimRenderer(viewRepresentable.renderContext)
         super.init()
+        #if os(macOS)
+        // Prevent the macOS beeping on keyDown events
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { _ in nil }
+        #endif
     }
 
     public func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {

--- a/Sources/VimKit/Views/VimRendererContainerViewCoordinator.swift
+++ b/Sources/VimKit/Views/VimRendererContainerViewCoordinator.swift
@@ -10,6 +10,20 @@ import MetalKit
 
 #if !os(visionOS)
 
+/// Keyboard navigation keys.
+private let keys: [GCKeyCode] = [
+    .keyW,
+    .keyS,
+    .keyA,
+    .keyD,
+    .keyE,
+    .keyQ,
+    .leftArrow,
+    .upArrow,
+    .rightArrow,
+    .downArrow
+]
+
 /// Provides a coordinator that is responsible for rendering into it's MTKView representable.
 @MainActor
 public class VimRendererContainerViewCoordinator: NSObject, MTKViewDelegate {
@@ -125,7 +139,6 @@ extension VimRendererContainerViewCoordinator {
     // See: https://developer.apple.com/videos/play/wwdc2020/10617
     func pollKeyboardInput() {
         guard let keyboard = GCKeyboard.coalesced?.keyboardInput else { return }
-        let keys: [GCKeyCode] = [.keyW, .keyS, .keyA, .keyD, .keyE, .keyQ, .leftArrow, .upArrow, .rightArrow, .downArrow]
         for key in keys {
             if keyboard.button(forKeyCode: key)?.isPressed ?? false {
                 keyPressed(keyCode: key)

--- a/Sources/VimKit/Vim+Camera.swift
+++ b/Sources/VimKit/Vim+Camera.swift
@@ -28,7 +28,7 @@ extension Vim {
 
         /// Holds our scene rotation transform which is used to
         /// convert from other cameras (such as ARKit or VisionPro).
-        var sceneTransform: float4x4 = .identity
+        public var sceneTransform: float4x4 = .identity
 
         /// The position and orientation of the camera in world coordinate space.
         /// The transform follows left-handed convention where the postive z-axis points up and the

--- a/Sources/VimKitCompositor/LayerRenderer/VimCompositorRenderer.swift
+++ b/Sources/VimKitCompositor/LayerRenderer/VimCompositorRenderer.swift
@@ -37,6 +37,14 @@ public class VimCompositorRenderer: VimRenderer {
         self.clock = LayerRenderer.Clock()
         super.init(context)
 
+        // Wait for geometry to load into a ready state
+        context.vim.geometry?.$state.sink { state in
+            Task { @MainActor in
+                guard state == .ready else { return }
+                self.start()
+            }
+        }.store(in: &subscribers)
+
         // Subscribe to hand tracking updates
         context.dataProvider.$handUpdates.sink { (_) in
         }.store(in: &subscribers)
@@ -172,7 +180,7 @@ extension VimCompositorRenderer {
                 cameraPosition: camera.position,
                 viewMatrix: camera.viewMatrix,
                 projectionMatrix: camera.projectionMatrix,
-                sceneTransform: camera.transform
+                sceneTransform: camera.sceneTransform
             )
         }
 

--- a/Sources/VimKitCompositor/LayerRenderer/VimImmersiveSpaceContent.swift
+++ b/Sources/VimKitCompositor/LayerRenderer/VimImmersiveSpaceContent.swift
@@ -38,9 +38,8 @@ public struct VimImmersiveSpaceContent: ImmersiveSpaceContent {
                 dataProvider: dataProvider
             )
 
-            // Start the engine
+            // Initiate the rendering engine
             let engine = VimCompositorRenderer(compositorContext)
-            engine.start()
         }
     }
 }


### PR DESCRIPTION
# Description

- Fixed the skybox position by passing the correct `camera.sceneTransform` into the per frame `Uniforms`.
- When running `visionOS`, the render loop doesn't begin now until the geometry has been loaded and is in a `.ready` state.
- Also, supressing the annoying beeps on `macOS` when `.keyDown` events happen.

Fixes #67 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
