### PR TITLE
ICB Execution Range

### DIFF
--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -702,7 +702,7 @@ extension Geometry {
         }
 
         let commandQueue = device.makeCommandQueue()
-        var instanceCount = instances.count
+        var instanceCount = instances.count - 1
 
         guard !Task.isCancelled,
               let library = MTLContext.makeLibrary(),
@@ -723,10 +723,9 @@ extension Geometry {
         computeEncoder.setBuffer(instancesBuffer, offset: 0, index: 2)
         computeEncoder.setBuffer(meshesBuffer, offset: 0, index: 3)
         computeEncoder.setBuffer(submeshesBuffer, offset: 0, index: 4)
-        computeEncoder.setBytes(&instanceCount, length: MemoryLayout<Int>.size, index: 5)
 
         // Set the thread group size and dispatch
-        let gridSize: MTLSize = .init(width: 1, height: 1, depth: 1)
+        let gridSize: MTLSize = .init(width: instanceCount, height: 1, depth: 1)
         let width = pipelineState.threadExecutionWidth
         let height = pipelineState.maxTotalThreadsPerThreadgroup / width
         let threadgroupSize: MTLSize = .init(width: width, height: height, depth: 1)

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -673,9 +673,9 @@ extension Geometry {
         computeEncoder.setBytes(&indicesCount, length: MemoryLayout<Int>.size, index: 5)
 
         // Set the thread group size and dispatch
-        let gridSize = MTLSizeMake(1, 1, 1)
-        let maxThreadsPerGroup = pipelineState.maxTotalThreadsPerThreadgroup
-        let threadgroupSize = MTLSizeMake(maxThreadsPerGroup, 1, 1)
+        let gridSize: MTLSize = .init(width: 1, height: 1, depth: 1)
+        let threadsPerGroup = pipelineState.maxTotalThreadsPerThreadgroup
+        let threadgroupSize: MTLSize = .init(width: threadsPerGroup, height: 1, depth: 1)
         computeEncoder.dispatchThreadgroups(gridSize, threadsPerThreadgroup: threadgroupSize)
 
         computeEncoder.endEncoding()
@@ -725,9 +725,9 @@ extension Geometry {
         computeEncoder.setBytes(&instanceCount, length: MemoryLayout<Int>.size, index: 5)
 
         // Set the thread group size and dispatch
-        let gridSize: MTLSize = MTLSizeMake(1, 1, 1)
-        let maxThreadsPerGroup = pipelineState.maxTotalThreadsPerThreadgroup
-        let threadgroupSize = MTLSizeMake(maxThreadsPerGroup, 1, 1)
+        let gridSize: MTLSize = .init(width: 1, height: 1, depth: 1)
+        let threadsPerGroup = pipelineState.maxTotalThreadsPerThreadgroup
+        let threadgroupSize: MTLSize = .init(width: threadsPerGroup, height: 1, depth: 1)
         computeEncoder.dispatchThreadgroups(gridSize, threadsPerThreadgroup: threadgroupSize)
 
         computeEncoder.endEncoding()

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -540,9 +540,7 @@ public class Geometry: ObservableObject, @unchecked Sendable {
     /// Provides the offset into instanced meshes where the transparent instanced meshes begin.
     /// This vale can be used as the buffer offset by multiplying with `MemoryLayout<InstancedMesh>.size`.
     public lazy var transparentInstancedMeshesOffset: Int = {
-        instancedMeshes.firstIndex { instancedMesh in
-            instancedMesh.transparent == true
-        } ?? .zero
+        instancedMeshes.firstIndex { $0.transparent == true } ?? .zero
     }()
 
     // MARK: Materials

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -118,6 +118,7 @@ public class Geometry: ObservableObject, @unchecked Sendable {
         publish(state: .loading)
 
         let device = MTLContext.device
+        let supportsIndirectCommandBuffers = device.supportsFamily(.apple4)
         let cacheDir = FileManager.default.cacheDirectory
 
         // 1) Build the positions (vertex) buffer
@@ -158,7 +159,11 @@ public class Geometry: ObservableObject, @unchecked Sendable {
 
         // 10 Start indexing the file
         publish(state: .indexing)
-        await bvh = BVH(self)
+
+        // Don't bother building the bvh tree if indirect command buffers are supported
+        if !supportsIndirectCommandBuffers {
+            await bvh = BVH(self)
+        }
         incrementProgressCount()
 
         publish(state: .ready)

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -728,8 +728,8 @@ extension Geometry {
         let gridSize: MTLSize = .init(width: instanceCount, height: 1, depth: 1)
         let width = pipelineState.threadExecutionWidth
         let height = pipelineState.maxTotalThreadsPerThreadgroup / width
-        let threadgroupSize: MTLSize = .init(width: width, height: height, depth: 1)
-        computeEncoder.dispatchThreadgroups(gridSize, threadsPerThreadgroup: threadgroupSize)
+        let threadsPerThreadgroup: MTLSize = .init(width: width, height: height, depth: 1)
+        computeEncoder.dispatchThreads(gridSize, threadsPerThreadgroup: threadsPerThreadgroup)
 
         computeEncoder.endEncoding()
         commandBuffer.commit()

--- a/Sources/VimKit/Geometry.swift
+++ b/Sources/VimKit/Geometry.swift
@@ -674,8 +674,9 @@ extension Geometry {
 
         // Set the thread group size and dispatch
         let gridSize: MTLSize = .init(width: 1, height: 1, depth: 1)
-        let threadsPerGroup = pipelineState.maxTotalThreadsPerThreadgroup
-        let threadgroupSize: MTLSize = .init(width: threadsPerGroup, height: 1, depth: 1)
+        let width = pipelineState.threadExecutionWidth
+        let height = pipelineState.maxTotalThreadsPerThreadgroup / width
+        let threadgroupSize: MTLSize = .init(width: width, height: height, depth: 1)
         computeEncoder.dispatchThreadgroups(gridSize, threadsPerThreadgroup: threadgroupSize)
 
         computeEncoder.endEncoding()
@@ -726,8 +727,9 @@ extension Geometry {
 
         // Set the thread group size and dispatch
         let gridSize: MTLSize = .init(width: 1, height: 1, depth: 1)
-        let threadsPerGroup = pipelineState.maxTotalThreadsPerThreadgroup
-        let threadgroupSize: MTLSize = .init(width: threadsPerGroup, height: 1, depth: 1)
+        let width = pipelineState.threadExecutionWidth
+        let height = pipelineState.maxTotalThreadsPerThreadgroup / width
+        let threadgroupSize: MTLSize = .init(width: width, height: height, depth: 1)
         computeEncoder.dispatchThreadgroups(gridSize, threadsPerThreadgroup: threadgroupSize)
 
         computeEncoder.endEncoding()

--- a/Sources/VimKit/Renderer/RenderPass+Indirect.swift
+++ b/Sources/VimKit/Renderer/RenderPass+Indirect.swift
@@ -303,6 +303,7 @@ class RenderPassIndirect: RenderPass {
         self.computeFunction = computeFunction
     }
 
+    /// Makes the indirect command buffer struct.
     private func makeIndirectCommandBuffers() {
 
         guard let computeFunction else { return }
@@ -392,6 +393,7 @@ class RenderPassIndirect: RenderPass {
         depthPyramidTexture?.label = labelTextureDepthPyramid
     }
 
+    /// Makes the rasterization map data.
     private func makeRasterizationMap() {
 
         guard screenSize != .zero else { return }
@@ -427,17 +429,17 @@ class RenderPassIndirect: RenderPass {
         return renderPassDescriptor
     }
 
+    /// Makes the execution range buffer.
+    /// - Parameter totalCommands: the total amount of commands the indirect command buffer supports.
+    /// - Returns: a new metal buffer cf MTLIndirectCommandBufferExecutionRange
     private func makeExecutionRange(_ totalCommands: Int = maxCommandCount) -> MTLBuffer? {
 
-        //        guard let executionRange = device.makeBuffer(length: MemoryLayout<MTLIndirectCommandBufferExecutionRange>.size * executionRangeCount,
-        //                                                     options: [.storageModeShared]) else { return }
         let rangeCount = Int(ceilf(Float(totalCommands)/Float(maxCommandCount)))
         var ranges: [Range<Int>] = .init()
         for i in 0..<rangeCount {
             let start = i * maxCommandCount
             let end = min(start + maxCommandCount, totalCommands)
             let range = start..<end
-
             ranges.append(range)
         }
 
@@ -445,7 +447,6 @@ class RenderPassIndirect: RenderPass {
             MTLIndirectCommandBufferExecutionRange(location: UInt32($0.lowerBound), length: UInt32($0.upperBound))
         }
 
-        // 16384
         let length = MemoryLayout<MTLIndirectCommandBufferExecutionRange>.size * executionRanges.count
         return device.makeBuffer(bytes: &executionRanges, length: length, options: [.storageModeShared])
     }

--- a/Sources/VimKit/Renderer/RenderPass+Indirect.swift
+++ b/Sources/VimKit/Renderer/RenderPass+Indirect.swift
@@ -215,17 +215,8 @@ class RenderPassIndirect: RenderPass {
     ///   - descriptor: the draw descriptor to use
     ///   - renderEncoder: the render encoder to use
     private func drawIndirect(descriptor: DrawDescriptor, renderEncoder: MTLRenderCommandEncoder) {
-        guard let geometry, let icb else { return }
-
-        //let gridSize = geometry.gridSize
-        // Build the range of commands to execute
-        //let range = 0..<1024 * 16
-        let range = 0..<geometry.gridSize.width * geometry.gridSize.height
-        renderEncoder.executeCommandsInBuffer(icb.commandBuffer, range: range)
-
-        // Execute the commands in range
-//        let offset = 0
-//        renderEncoder.executeCommandsInBuffer(icb.commandBuffer, indirectBuffer: icb.executionRange, offset: offset)
+        guard let icb else { return }
+        renderEncoder.executeCommandsInBuffer(icb.commandBuffer, indirectBuffer: icb.executionRange, offset: 0)
     }
 
     private func drawCulling(descriptor: DrawDescriptor, renderEncoder: MTLRenderCommandEncoder) {

--- a/Sources/VimKit/Renderer/RenderPass+Visibility.swift
+++ b/Sources/VimKit/Renderer/RenderPass+Visibility.swift
@@ -46,7 +46,7 @@ class RenderPassVisibility: RenderPass {
     var currentResults: [Int] = .init()
     /// Returns the subset of instanced mesh indexes that have returned true from the occlusion query.
     var currentVisibleResults: [Int] = .init()
-    /// Combine Subscribers which drive rendering events
+    /// Combine subscribers.
     var subscribers = Set<AnyCancellable>()
 
     /// Initializes the render pass with the provided rendering context.

--- a/Sources/VimKitShaders/Resources/Indirect.metal
+++ b/Sources/VimKitShaders/Resources/Indirect.metal
@@ -188,7 +188,7 @@ static void encodeAndDraw(thread render_command &cmd,
 //   - icbContainer: The pointer to the indirect command buffer container.
 //   - rasterRateMapData: The raster data map.
 //   - depthPyramidTexture: The depth texture.
-kernel void encodeIndirectCommands(uint2 threadPosition [[thread_position_in_grid]],
+kernel void encodeIndirectRenderCommands(uint2 threadPosition [[thread_position_in_grid]],
                                    uint2 gridSize [[threads_per_grid]],
                                    constant float *positions [[buffer(KernelBufferIndexPositions)]],
                                    constant float *normals [[buffer(KernelBufferIndexNormals)]],

--- a/Sources/VimKitShaders/include/ShaderTypes.h
+++ b/Sources/VimKitShaders/include/ShaderTypes.h
@@ -143,8 +143,9 @@ typedef NS_ENUM(EnumBackingType, KernelBufferIndex) {
     KernelBufferIndexMaterials = 8,
     KernelBufferIndexColors = 9,
     KernelBufferIndexCommandBufferContainer = 10,
-    KernelBufferIndexRasterizationRateMapData = 11,
-    KernelBufferIndexDepthPyramidSize = 12
+    KernelBufferIndexExecutionRange = 11,
+    KernelBufferIndexRasterizationRateMapData = 12,
+    KernelBufferIndexDepthPyramidSize = 13
 };
 
 // Enum constants for argument buffer indices


### PR DESCRIPTION
# Description

Uses the `executeCommandsInBuffer` with the `indirectBuffer` argument instead of executing commands in range.

Also, maximizes parallelization of computing the bounding boxes by making a grid the width of the instances and using the `thread_position_in_grid` as the index.

### Parallelization Results:
✅ Before: `Bounding boxes computed in [00:00:07.970]`
✅  After: `Bounding boxes computed in [00:00:00.366]`


Fixes #77 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
