### PR TITLE
GPU Family Checks

### DIFF
--- a/Sources/VimKit/Renderer/RenderPass+Shapes.swift
+++ b/Sources/VimKit/Renderer/RenderPass+Shapes.swift
@@ -59,7 +59,7 @@ class RenderPassShapes: RenderPass {
     ///   - renderEncoder: the render encoder to use
     private func encode(descriptor: DrawDescriptor, renderEncoder: MTLRenderCommandEncoder) {
 
-        guard let pipelineState, let normalsBuffer = geometry?.normalsBuffer else { return }
+        guard let pipelineState else { return }
         renderEncoder.setRenderPipelineState(pipelineState)
         renderEncoder.setDepthStencilState(depthStencilState)
 


### PR DESCRIPTION
# Description

Performing checks if the GPU family supports non-uniform threadgroup sizes. 

If the GPU family is `.apple4` or greater we can use the `MTLComputeCommandEncoder.dispatchThreads(_:threadsPerThreadgroup:)` othwerwise we fall back to `MTLComputeCommandEncoder.dispatchThreadgroups(_:threadsPerThreadgroup:)`

This is primarily used for running on simulators and not the native mac app.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
